### PR TITLE
enable tests for query and metrics

### DIFF
--- a/tests/tests_custom.yml
+++ b/tests/tests_custom.yml
@@ -10,6 +10,3 @@
         metrics_retention_days: 5
         metrics_graph_service: yes
         metrics_query_service: yes
-  when:
-    - __metrics_packages_query | d([])
-    - __metrics_packages_graph | d([])

--- a/tests/tests_graph.yml
+++ b/tests/tests_graph.yml
@@ -7,5 +7,3 @@
     - role: linux-system-roles.metrics
       vars:
         metrics_graph_service: yes
-  when:
-    - __metrics_packages_graph | d([])

--- a/tests/tests_query.yml
+++ b/tests/tests_query.yml
@@ -7,5 +7,3 @@
     - role: linux-system-roles.metrics
       vars:
         metrics_query_service: yes
-  when:
-    - __metrics_packages_query | d([])


### PR DESCRIPTION
the `when` clause was causing the role to be skipped.  It should
be removed to enable running the tests.
