### PR TITLE
Remove pcp-doc from packages

### DIFF
--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -3,7 +3,6 @@
 # Put internal variables here with CentOS 6 specific values.
 
 __metrics_packages_extra:
-  - pcp-doc
   - pcp-pmda-dm
   - pcp-pmda-nfsclient
   - pcp-system-tools

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -3,7 +3,6 @@
 # Put internal variables here with Red Hat Enterprise Linux 6 specific values.
 
 __metrics_packages_extra:
-  - pcp-doc
   - pcp-pmda-dm
   - pcp-pmda-nfsclient
   - pcp-system-tools


### PR DESCRIPTION
A package with documentation is unlikely to be required for running a service.