### PR TITLE
Corrections to recently added metrics role functionality

### DIFF
--- a/examples/pcp_bpftrace.yml
+++ b/examples/pcp_bpftrace.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up bpftrace for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_bpftrace: yes

--- a/examples/pcp_elasticsearch.yml
+++ b/examples/pcp_elasticsearch.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up Elasticsearch for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_elasticsearch: yes
+        metrics_into_elasticsearch: yes

--- a/examples/pcp_sqlserver.yml
+++ b/examples/pcp_sqlserver.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up SQL Server for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_mssql: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+---
+
+__metrics_domains: []
+__metrics_accounts: {}


### PR DESCRIPTION
Tackle a number of issues Jan has uncovered in testing:
- remove recursion between the higher and lower level roles
- the bpftrace, elasticsearch and mssql agent installations
  are performed via single pcp role invocation from metrics
- fix incorrect macro name for sasl authentication packages
- fix incorrect macro name for sasl user names
- fix incorrect invocation of saslpasswd2
- added some more example playbooks

Small cleanups and inconsistencies throughout corrected also.
New sub-roles now also get a metric_provider variable passed
in to allow for alternate (and/or minimal) implementations.

Resolves https://github.com/linux-system-roles/metrics/issues/47
Resolves https://github.com/linux-system-roles/metrics/issues/46
Resolves https://github.com/linux-system-roles/metrics/issues/34
Resolves https://github.com/linux-system-roles/metrics/issues/33