### PR TITLE
Corrections to recently added metrics role functionality

### DIFF
--- a/examples/pcp_bpftrace.yml
+++ b/examples/pcp_bpftrace.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up bpftrace for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_bpftrace: yes

--- a/examples/pcp_elasticsearch.yml
+++ b/examples/pcp_elasticsearch.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up Elasticsearch for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_elasticsearch: yes
+        metrics_into_elasticsearch: yes

--- a/examples/pcp_sqlserver.yml
+++ b/examples/pcp_sqlserver.yml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Set up SQL Server for use with PCP
+  hosts: monitoring
+
+  roles:
+    - role: linux-system-roles.metrics
+      vars:
+        metrics_provider: pcp
+        metrics_from_mssql: yes

--- a/roles/performancecopilot_metrics_bpftrace/README.md
+++ b/roles/performancecopilot_metrics_bpftrace/README.md
@@ -9,11 +9,20 @@ Uses features of PCP v5.1 and later, and makes use of Cyrus SASL (Simple Authent
 ## Role Variables
 
 ```yaml
-bpftrace_users:
-  - { user: metrics, sasluser: metrics, saslpassword: p4ssw0rd }
+bpftrace_metrics_provider: 'pcp'
 ```
 
-Local system accounts that are able to load new bpftrace scripts.  These accounts will be able to load eBPF code into the running kernel, which is a privileged operation.  The mandatory value for the variable is an array of username-to-password mappings.  SASL accounts can also be configured using this mechanism, for remote [pmcd(1)](http://man7.org/linux/man-pages/man1/pmcd.1.html) authentication.
+The metrics collector to use to provide metrics.
+
+This can be either set to 'none' for local bpftrace package installation only.
+The default value 'pcp' configures bpftrace for use with Performance Co-Pilot.
+
+```yaml
+bpftrace_users:
+  - { user: metrics }
+```
+
+Local user accounts that are allowed to load new bpftrace scripts.  These accounts will be able to load eBPF code into the running kernel, which is a privileged operation.  The mandatory value for the variable is an array of dictionaries containing account names under the 'user' key.  Other authentication mechanisms can share these dictionaries, e.g. for remote [pmcd(1)](http://man7.org/linux/man-pages/man1/pmcd.1.html) authentication with PCP using SASL.
 
 ## Dependencies
 
@@ -29,10 +38,8 @@ Make bpftrace metrics available to PCP analysis tools, and allow the local *graf
     - role: performancecopilot.metrics.bpftrace
       vars:
         bpftrace_users:
-        - username: metrics
-          password: p4ssw0rd
-        - username: grafana
-          password: adm1n!
+        - { user: 'grafana' }
+        - { user: 'metrics', sasluser: 'metrics', saslpassword: 'p4ssw0rd' }
 ```
 
 ## License

--- a/roles/performancecopilot_metrics_bpftrace/defaults/main.yml
+++ b/roles/performancecopilot_metrics_bpftrace/defaults/main.yml
@@ -2,4 +2,4 @@
 ---
 
 bpftrace_users:
-  - { user: metrics, sasluser: metrics, saslpassword: admin }
+  - { user: metrics }

--- a/roles/performancecopilot_metrics_bpftrace/tasks/main.yml
+++ b/roles/performancecopilot_metrics_bpftrace/tasks/main.yml
@@ -10,27 +10,32 @@
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
   when: item is file
 
+- name: Establish bpftrace metrics package names
+  set_fact:
+    __bpftrace_packages_extra: "{{ __bpftrace_packages_pcp }}"
+  when: bpftrace_metrics_provider == 'pcp'
+
+- name: Install needed bpftrace metrics packages
+  package:
+    name: "{{ __bpftrace_packages + __bpftrace_packages_extra }}"
+    state: present
+
 - name: Extract allowed bpftrace user accounts
   set_fact:
     __bpftrace_usernames: "{{ __bpftrace_usernames }},{{ item.user }}"
+  when: item.user is defined
   with_items: "{{ bpftrace_users }}"
 
-- name: Ensure PCP bpftrace agent config dir exists
+- name: Ensure PCP bpftrace configuration directory exists
   file:
     path: "{{ __bpftrace_conf_dir }}"
     state: directory
     mode: 0755
+  when: bpftrace_metrics_provider == 'pcp'
 
 - name: Ensure PCP bpftrace agent is configured
   template:
     src: bpftrace.conf.j2
     dest: "{{ __bpftrace_conf }}"
     mode: 0600
-
-- name: Ensure PCP bpftrace metrics are available
-  import_role:
-    name: performancecopilot_metrics_pcp
-  vars:
-    pcp_accounts: "{{ bpftrace_users }}"
-    pcp_optional_agents: ['bpftrace']
-    pcp_optional_packages: "{{ __bpftrace_packages_extra }}"
+  when: bpftrace_metrics_provider == 'pcp'

--- a/roles/performancecopilot_metrics_bpftrace/vars/Debian.yml
+++ b/roles/performancecopilot_metrics_bpftrace/vars/Debian.yml
@@ -2,4 +2,10 @@
 ---
 # Put internal variables here with Debian specific values.
 
+__bpftrace_packages:
+  - bpftrace
+
 __bpftrace_packages_extra: []
+
+__bpftrace_packages_pcp:
+  - pcp

--- a/roles/performancecopilot_metrics_bpftrace/vars/RedHat.yml
+++ b/roles/performancecopilot_metrics_bpftrace/vars/RedHat.yml
@@ -2,5 +2,10 @@
 ---
 # Put internal variables here with Red Hat specific values.
 
-__bpftrace_packages_extra:
+__bpftrace_packages:
+  - bpftrace
+
+__bpftrace_packages_extra: []
+
+__bpftrace_packages_pcp:
   - pcp-pmda-bpftrace

--- a/roles/performancecopilot_metrics_bpftrace/vars/default.yml
+++ b/roles/performancecopilot_metrics_bpftrace/vars/default.yml
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
+
+bpftrace_metrics_provider: 'pcp'

--- a/roles/performancecopilot_metrics_elasticsearch/tasks/main.yml
+++ b/roles/performancecopilot_metrics_elasticsearch/tasks/main.yml
@@ -10,11 +10,31 @@
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
   when: item is file
 
-- name: Ensure PCP Elasticsearch agent config dir exists
+- name: Establish Elasticsearch metrics package names
+  set_fact:
+    __elasticsearch_packages_extra: "{{ __elasticsearch_packages_extra + __elasticsearch_packages_pcp }}"
+  when:
+    - elasticsearch_metrics_provider == 'pcp'
+    - elasticsearch_agent|d(false)|bool
+
+- name: Establish Elasticsearch metrics export package names
+  set_fact:
+    __elasticsearch_packages_extra: "{{ __elasticsearch_packages_extra + __elasticsearch_packages_export_pcp }}"
+  when:
+    - elasticsearch_metrics_provider == 'pcp'
+    - elasticsearch_export_metrics|d(false)|bool
+
+- name: Install needed Elasticsearch metrics packages
+  package:
+    name: "{{ __elasticsearch_packages_extra }}"
+    state: present
+
+- name: Ensure PCP Elasticsearch agent configuration directory exists
   file:
     path: "{{ __elasticsearch_conf_dir }}"
     state: directory
     mode: 0755
+  when: elasticsearch_metrics_provider == 'pcp'
 
 - name: Ensure PCP Elasticsearch agent is configured
   template:
@@ -22,24 +42,8 @@
     dest: "{{ __elasticsearch_conf }}"
     mode: 0600
   when:
-    - elasticsearch_agent | d(false) | bool
-
-- name: Ensure PCP Elasticsearch metrics are available
-  import_role:
-    name: performancecopilot_metrics_pcp
-  vars:
-    pcp_optional_agents: [elasticsearch]
-    pcp_optional_packages: "{{ __elasticsearch_packages_extra }}"
-  when:
-    - elasticsearch_agent | d(false) | bool
-
-- name: Install PCP Elasticsearch export package
-  package:
-    name: "{{ __elasticsearch_packages_export }}"
-    state: present
-  when:
-    - elasticsearch_export_metrics | bool
-    - __elasticsearch_packages_export | d([])
+    - elasticsearch_metrics_provider == 'pcp'
+    - elasticsearch_agent|d(false)|bool
 
 - name: Ensure PCP Elasticsearch export service exists
   template:
@@ -47,12 +51,14 @@
     dest: "{{ __elasticsearch_service_path }}/pcp2elasticsearch.service"
     mode: 0600
   when:
-    - elasticsearch_export_metrics | bool
+    - elasticsearch_metrics_provider == 'pcp'
+    - elasticsearch_export_metrics|d(false)|bool
 
-- name: Ensure PCP Elasticsearch export is running and enabled on boot.
+- name: Ensure PCP Elasticsearch export is running and enabled on boot
   service:
     name: pcp2elasticsearch
     state: started
     enabled: yes
   when:
-    - elasticsearch_export_metrics | bool
+    - elasticsearch_metrics_provider == 'pcp'
+    - elasticsearch_export_metrics|d(false)|bool

--- a/roles/performancecopilot_metrics_elasticsearch/vars/Debian.yml
+++ b/roles/performancecopilot_metrics_elasticsearch/vars/Debian.yml
@@ -3,5 +3,7 @@
 # Put internal variables here with Debian specific values.
 
 __elasticsearch_service_path: /lib/systemd/system
-__elasticsearch_packages_extra: []
-__elasticsearch_packages_export: []
+__elasticsearch_packages_pcp:
+  - pcp
+__elasticsearch_packages_export_pcp:
+  - pcp

--- a/roles/performancecopilot_metrics_elasticsearch/vars/RedHat.yml
+++ b/roles/performancecopilot_metrics_elasticsearch/vars/RedHat.yml
@@ -3,7 +3,7 @@
 # Put internal variables here with Red Hat specific values.
 
 __elasticsearch_service_path: /usr/lib/systemd/system
-__elasticsearch_packages_extra:
+__elasticsearch_packages_pcp:
   - pcp-pmda-elasticsearch
-__elasticsearch_packages_export:
+__elasticsearch_packages_export_pcp:
   - pcp-export-pcp2elasticsearch

--- a/roles/performancecopilot_metrics_elasticsearch/vars/default.yml
+++ b/roles/performancecopilot_metrics_elasticsearch/vars/default.yml
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
+
+elasticsearch_metrics_provider: 'pcp'

--- a/roles/performancecopilot_metrics_elasticsearch/vars/main.yml
+++ b/roles/performancecopilot_metrics_elasticsearch/vars/main.yml
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 
+__elasticsearch_packages_extra: []
 __elasticsearch_conf_dir: /etc/pcp/elasticsearch
 __elasticsearch_conf: "{{ __elasticsearch_conf_dir }}/elasticsearch.conf"
 __elasticsearch_export_conf: /etc/pcp/pcp2elasticsearch.conf

--- a/roles/performancecopilot_metrics_grafana/tasks/main.yml
+++ b/roles/performancecopilot_metrics_grafana/tasks/main.yml
@@ -22,6 +22,14 @@
     mode: 0640
   notify: restart grafana
 
+- name: Ensure Grafana configuration directory exists
+  file:
+    path: "{{ __grafana_provisioning_path }}/datasources"
+    state: directory
+    group: grafana
+    owner: root
+    mode: 0750
+
 - name: Ensure Grafana service is configured with datasources
   template:
     src: grafana-pcp-datasources.yaml.j2

--- a/roles/performancecopilot_metrics_grafana/vars/default.yml
+++ b/roles/performancecopilot_metrics_grafana/vars/default.yml
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
+
+grafana_metrics_provider: 'pcp'

--- a/roles/performancecopilot_metrics_mssql/tasks/main.yml
+++ b/roles/performancecopilot_metrics_mssql/tasks/main.yml
@@ -10,21 +10,27 @@
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
   when: item is file
 
-- name: Ensure PCP SQL Server agent config dir exists
+- name: Establish SQL Server metrics package names
+  set_fact:
+    __mssql_packages_extra: "{{ __mssql_packages_pcp }}"
+  when: mssql_metrics_provider == 'pcp'
+
+- name: Install needed SQL Server metrics packages
+  package:
+    name: "{{ __mssql_packages_extra }}"
+    state: present
+  when: __mssql_packages_extra|d([])
+
+- name: Ensure PCP SQL Server agent configuration directory exists
   file:
     path: "{{ __mssql_conf_dir }}"
     state: directory
     mode: 0755
+  when: mssql_metrics_provider == 'pcp'
 
 - name: Ensure PCP SQL Server agent is configured
   template:
     src: mssql.conf.j2
     dest: "{{ __mssql_conf }}"
     mode: 0600
-
-- name: Ensure PCP SQL Server metrics are available
-  import_role:
-    name: performancecopilot_metrics_pcp
-  vars:
-    pcp_optional_agents: [mssql]
-    pcp_optional_packages: "{{ __mssql_packages_extra }}"
+  when: mssql_metrics_provider == 'pcp'

--- a/roles/performancecopilot_metrics_mssql/vars/Debian.yml
+++ b/roles/performancecopilot_metrics_mssql/vars/Debian.yml
@@ -2,4 +2,5 @@
 ---
 # Put internal variables here with Debian specific values.
 
-__mssql_packages_extra: []
+__mssql_packages_pcp:
+  - pcp

--- a/roles/performancecopilot_metrics_mssql/vars/RedHat.yml
+++ b/roles/performancecopilot_metrics_mssql/vars/RedHat.yml
@@ -2,5 +2,5 @@
 ---
 # Put internal variables here with Red Hat specific values.
 
-__mssql_packages_extra:
+__mssql_packages_pcp:
   - pcp-pmda-mssql

--- a/roles/performancecopilot_metrics_mssql/vars/default.yml
+++ b/roles/performancecopilot_metrics_mssql/vars/default.yml
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
+
+mssql_metrics_provider: 'pcp'

--- a/roles/performancecopilot_metrics_mssql/vars/main.yml
+++ b/roles/performancecopilot_metrics_mssql/vars/main.yml
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
 
+__mssql_packages_extra: []
 __mssql_conf_dir: /etc/pcp/mssql
 __mssql_conf: "{{  __mssql_conf_dir  }}/mssql.conf"

--- a/roles/performancecopilot_metrics_pcp/tasks/main.yml
+++ b/roles/performancecopilot_metrics_pcp/tasks/main.yml
@@ -20,8 +20,8 @@
     name: "{{ __pcp_sasl_packages }}"
     state: present
   when:
-    - __pcp_sasl_packages | d([])
-    - pcp_sasl_accounts | d([])
+    - __pcp_sasl_packages|d([])
+    - pcp_accounts|d({})
 
 - include_tasks: pmcd.yml
 
@@ -30,4 +30,4 @@
 - include_tasks: pmlogger.yml
 
 - include_tasks: pmproxy.yml
-  when: pcp_rest_api | bool
+  when: pcp_rest_api|d(false)|bool

--- a/roles/performancecopilot_metrics_pcp/tasks/pmcd.yml
+++ b/roles/performancecopilot_metrics_pcp/tasks/pmcd.yml
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: List optional metric collection agents to be enabled.
+- name: List optional metric collection agents to be enabled
   debug:
     msg: "NeedInstall agent: {{ item }} from {{ pcp_optional_agents }}"
   loop: "{{ pcp_optional_agents|default([]) }}"
 
-- name: Extract metric collection configuration file content.
+- name: Extract metric collection configuration file content
   command: "cat {{ __pcp_pmcd_conf }}"
   register: pmcd_conf
   changed_when: false
 
-- name: Ensure optional metric collection agents are enabled.
+- name: Ensure optional metric collection agents are enabled
   file:
     path: "{{ __pcp_agents_path }}/{{ item }}/.NeedInstall"
     mode: u=rw,g=r,o=r
@@ -20,7 +20,7 @@
   when: pmcd_conf.stdout.find(item) == -1
   notify: restart pmcd
 
-- name: Ensure explicit metric label path exists.
+- name: Ensure explicit metric label path exists
   file:
     path: "{{ __pcp_explicit_labels_path }}"
     state: directory
@@ -28,7 +28,7 @@
     owner: root
     group: root
 
-- name: Ensure implicit metric label path exists.
+- name: Ensure implicit metric label path exists
   file:
     path: "{{ __pcp_implicit_labels_path }}"
     state: directory
@@ -36,58 +36,58 @@
     owner: root
     group: root
 
-- name: Ensure any explicit metric labels are configured.
+- name: Ensure any explicit metric labels are configured
   template:
     src: pmcd.explicit.labels.j2
     dest: "{{ __pcp_explicit_labels_path }}/ansible-managed"
     mode: 0644
   notify: restart pmcd
 
-- name: Ensure any implicit metric labels are configured.
+- name: Ensure any implicit metric labels are configured
   template:
     src: pmcd.implicit.labels.j2
     dest: "{{ __pcp_implicit_labels_path }}/ansible-managed"
     mode: 0644
   notify: restart pmcd
 
-- name: Ensure performance metric collector is configured.
+- name: Ensure performance metric collector is configured
   template:
     src: pmcd.defaults.j2
     dest: "{{ __pcp_pmcd_defaults_path }}"
     mode: 0644
   notify: restart pmcd
 
-- name: Ensure performance metric collector system accounts are configured.
+- name: Ensure performance metric collector system accounts are configured
   user:
     name: "{{ item.user }}"
     system: yes
   when: item.user is defined
   with_items: "{{ pcp_accounts }}"
 
-- name: Ensure performance metric collector SASL accounts are configured.
+- name: Ensure performance metric collector SASL accounts are configured
   shell: |
     set -o pipefail
-    sasldblistusers2 -f "{{ __pcp_pmcd_sasldb_path }}" | grep -q "^{{ item.saslname }}@"
+    sasldblistusers2 -f "{{ __pcp_pmcd_sasldb_path }}" | grep -q "^{{ item.sasluser }}@"
     [ $? -eq 0 ] && exit 0
-    echo "Creating new {{ item.saslname }} user in {{ __pcp_pmcd_sasldb_path }}"
-    echo "{{ item.saslpassword }}" | saslpasswd2 -na pmcd "{{ item.saslname }}"
+    echo "Creating new {{ item.sasluser }} user in {{ __pcp_pmcd_sasldb_path }}"
+    echo "{{ item.saslpassword }}" | saslpasswd2 -a pmcd "{{ item.sasluser }}"
     chown root:pcp "{{ __pcp_pmcd_sasldb_path }}"
     chmod 640 "{{ __pcp_pmcd_sasldb_path }}"
     exit 0
   register: ensure_sasl_configured
   changed_when: "'Creating new SASL account' in ensure_sasl_configured.stdout"
-  when: item.saslname is defined
+  when: item.sasluser is defined
   with_items: "{{ pcp_accounts }}"
 
-- name: Ensure performance metric collector authentication is configured.
+- name: Ensure performance metric collector authentication is configured
   template:
     src: pmcd.sasl2.conf.j2
     dest: "{{ __pcp_pmcd_saslconf_path }}"
     mode: 0644
   notify: restart pmcd
-  when: pcp_accounts | d([])
+  when: pcp_accounts|d([])
 
-- name: Ensure performance metric collector is running and enabled on boot.
+- name: Ensure performance metric collector is running and enabled on boot
   service:
     name: pmcd
     state: started

--- a/roles/performancecopilot_metrics_pcp/tasks/pmie.yml
+++ b/roles/performancecopilot_metrics_pcp/tasks/pmie.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: Ensure extra performance rule group directories exist.
+- name: Ensure extra performance rule group directories exist
   file:
     path: "{{ __pcp_pmieconf_path }}/{{ item }}"
     state: directory
@@ -10,7 +10,7 @@
     mode: 0755
   loop: "{{ __pcp_pmieconf_groups|default([]) }}"
 
-- name: Ensure extra performance rule group link directories exist.
+- name: Ensure extra performance rule group link directories exist
   file:
     path: "{{ __pcp_pmieconf_link_path }}/{{ item }}"
     state: directory
@@ -19,7 +19,7 @@
     mode: 0755
   loop: "{{ __pcp_pmieconf_groups|default([]) }}"
 
-- name: Ensure extra performance rules are installed for targeted hosts.
+- name: Ensure extra performance rules are installed for targeted hosts
   copy:
     src: "files/{{ item }}"
     dest: "{{ __pcp_pmieconf_path }}/{{ item }}"
@@ -28,7 +28,7 @@
     mode: '0644'
   loop: "{{ __pcp_pmieconf_rules|default([]) }}"
 
-- name: Ensure extra rules symlinks have been created for targeted hosts.
+- name: Ensure extra rules symlinks have been created for targeted hosts
   file:
     src: "{{ __pcp_pmieconf_path }}/{{ item }}"
     dest: "{{ __pcp_pmieconf_link_path }}/{{ item }}"
@@ -36,7 +36,7 @@
     force: yes
   loop: "{{ __pcp_pmieconf_rules|default([]) }}"
 
-- name: Ensure performance metric inference is enabled for targeted hosts.
+- name: Ensure performance metric inference is enabled for targeted hosts
   template:
     src: pmie.control.j2
     dest: "{{ __pcp_pmie_control_path }}/{{ item }}"
@@ -44,7 +44,7 @@
   loop: "{{ pcp_target_hosts|default([]) }}"
   notify: restart pmie
 
-- name: Ensure performance metric inference is running and enabled on boot.
+- name: Ensure performance metric inference is running and enabled on boot
   service:
     name: pmie
     state: started

--- a/roles/performancecopilot_metrics_pcp/tasks/pmlogger.yml
+++ b/roles/performancecopilot_metrics_pcp/tasks/pmlogger.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: Ensure metric log location is configured.
+- name: Ensure metric log location is configured
   lineinfile:
     path: "{{ __pcp_conf }}"
     regexp: '^PCP_ARCHIVE_DIR='
@@ -10,21 +10,21 @@
     - restart pmlogger
     - restart pmproxy
 
-- name: Ensure performance metric logging is configured.
+- name: Ensure performance metric logging is configured
   template:
     src: pmlogger.defaults.j2
     dest: "{{ __pcp_pmlogger_defaults_path }}"
     mode: 0644
   notify: restart pmlogger
 
-- name: Ensure performance metric logging retention period is set.
+- name: Ensure performance metric logging retention period is set
   template:
     src: pmlogger.timers.j2
     dest: "{{ __pcp_pmlogger_timers_path }}"
     mode: 0644
   notify: restart pmlogger
 
-- name: Ensure performance metric logging is enabled for targeted hosts.
+- name: Ensure performance metric logging is enabled for targeted hosts
   template:
     src: pmlogger.control.j2
     dest: "{{ __pcp_pmlogger_control_path }}/{{ item }}"
@@ -32,7 +32,7 @@
   loop: "{{ __pcp_target_hosts|default([]) }}"
   notify: restart pmlogger
 
-- name: Ensure performance metric logging is running and enabled on boot.
+- name: Ensure performance metric logging is running and enabled on boot
   service:
     name: pmlogger
     state: started

--- a/roles/performancecopilot_metrics_pcp/tasks/pmproxy.yml
+++ b/roles/performancecopilot_metrics_pcp/tasks/pmproxy.yml
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: Ensure REST API, proxy and metric log discovery is configured.
+- name: Ensure REST API, proxy and metric log discovery is configured
   template:
     src: pmproxy.defaults.j2
     dest: "{{ __pcp_pmproxy_defaults_path }}"
     mode: 0644
   notify: restart pmproxy
 
-- name: Ensure REST API, proxy and log discovery is running and enabled on boot.
+- name: Ensure REST API, proxy and log discovery is running and enabled on boot
   service:
     name: pmproxy
     state: started

--- a/roles/performancecopilot_metrics_pcp/vars/RedHat.yml
+++ b/roles/performancecopilot_metrics_pcp/vars/RedHat.yml
@@ -7,6 +7,6 @@ __pcp_pmproxy_defaults_path: /etc/sysconfig/pmproxy
 __pcp_pmlogger_defaults_path: /etc/sysconfig/pmlogger
 __pcp_pmlogger_timers_path: /etc/sysconfig/pmlogger_timers
 
-__pcp_packages_sasl:
+__pcp_sasl_packages:
   - cyrus-sasl-lib
   - cyrus-sasl-scram

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,44 +1,76 @@
 # SPDX-License-Identifier: MIT
 ---
 
-- name: Setup metric collection service
-  vars:
-    pcp_pmlogger_discard: "{{ metrics_retention_days }}"
-    pcp_target_hosts: "{{ metrics_monitored_hosts }}"
-    pcp_rest_api: "{{ metrics_query_service|d(false)|bool or metrics_graph_service|d(false)|bool }}"
-  include_role:
-    name: "{{ role_path }}/roles/performancecopilot_metrics_pcp"
-  when: metrics_provider == 'pcp'
+- name: Add Elasticsearch to metrics domain list
+  set_fact:
+    __metrics_domains: "{{ __metrics_domains + [ 'elasticsearch' ] }}"
+  when: metrics_from_elasticsearch|d(false)|bool
 
-- name: Setup metric querying service
-  include_role:
-    name: "{{ role_path }}/roles/performancecopilot_metrics_redis"
-  when: metrics_query_service|d(false)|bool
+- name: Add SQL Server to metrics domain list
+  set_fact:
+    __metrics_domains: "{{ __metrics_domains + [ 'mssql' ] }}"
+  when: metrics_from_mssql|d(false)|bool
 
-- name: Setup metric graphing service
-  include_role:
-    name: "{{ role_path }}/roles/performancecopilot_metrics_grafana"
-  when: metrics_graph_service|d(false)|bool
+- name: Add bpftrace to metrics domain list
+  set_fact:
+    __metrics_domains: "{{ __metrics_domains + [ 'bpftrace' ] }}"
+  when: metrics_from_bpftrace|d(false)|bool
 
-- name: Setup Elasticsearch metrics
+- name: Setup metrics access for roles
+  set_fact:
+    __metrics_accounts:
+      - { user: "{{ metrics_username }}", sasluser: "{{ metrics_username }}", saslpassword: "{{ metrics_password }}" }
+  when: (metrics_username is defined) and (metrics_username|length > 0)
+
+- name: Configure Elasticsearch metrics
   vars:
     elasticsearch_agent: "{{ metrics_from_elasticsearch|d(false)|bool }}"
     elasticsearch_export_type: "{{ metrics_provider }}-{{ role_name }}"
     elasticsearch_export_index: "{{ metrics_provider }}"
     elasticsearch_export_metrics: "{{ metrics_into_elasticsearch|d(false)|bool }}"
+    elasticsearch_metrics_provider: "{{ metrics_provider }}"
   include_role:
     name: "{{ role_path }}/roles/performancecopilot_metrics_elasticsearch"
-  when: metrics_from_elasticsearch|d(false)|bool or metrics_into_elasticsearch|d(false)|bool
+  when: >
+    metrics_from_elasticsearch|d(false)|bool or
+    metrics_into_elasticsearch|d(false)|bool
 
-- name: Setup SQL Server metrics
+- name: Configure SQL Server metrics.
+  vars:
+    - mssql_metrics_provider: "{{ metrics_provider }}"
   include_role:
     name: "{{ role_path }}/roles/performancecopilot_metrics_mssql"
   when: metrics_from_mssql|d(false)|bool
 
-- name: Setup bpftrace metrics
+- name: Setup bpftrace metrics.
   vars:
-    bpftrace_users:
-      - { user: "{{ metrics_username }}", sasluser: "{{ metrics_username }}", saslpassword: "{{ metrics_password }}" }
+    bpftrace_users: "{{ __metrics_accounts }}"
+    bpftrace_metrics_provider: "{{ metrics_provider }}"
   include_role:
     name: "{{ role_path }}/roles/performancecopilot_metrics_bpftrace"
   when: metrics_from_bpftrace|d(false)|bool
+
+- name: Setup metric collection service.
+  vars:
+    pcp_pmlogger_discard: "{{ metrics_retention_days }}"
+    pcp_target_hosts: "{{ metrics_monitored_hosts }}"
+    pcp_optional_agents: "{{ __metrics_domains }}"
+    pcp_accounts: "{{ __metrics_accounts }}"
+    pcp_rest_api: "{{ metrics_query_service|d(false)|bool or metrics_graph_service|d(false)|bool }}"
+  include_role:
+    name: "{{ role_path }}/roles/performancecopilot_metrics_pcp"
+  when: metrics_provider == 'pcp'
+
+- name: Setup metric querying service.
+  vars:
+    redis_metrics_provider: "{{ metrics_provider }}"
+  include_role:
+    name: "{{ role_path }}/roles/performancecopilot_metrics_redis"
+  when: metrics_query_service|d(false)|bool
+
+- name: Setup metric graphing service.
+  vars:
+    grafana_metrics_provider: "{{ metrics_provider }}"
+  include_role:
+    name: "{{ role_path }}/roles/performancecopilot_metrics_grafana"
+  when: metrics_graph_service|d(false)|bool

--- a/tests/check_fullstack_pmdas.yml
+++ b/tests/check_fullstack_pmdas.yml
@@ -3,11 +3,9 @@
 - name: Check if PMDA packages are installed
   command: rpm -q pcp-pmda-{{ item }}
   loop:
-    - bcc
     - bpftrace
 
 - name: Check if PMDAs are installed
   shell: pcp | grep -E '^\s*pmda' | grep -w {{ item }}
   loop:
-    - bcc
     - bpftrace

--- a/tests/tests_bz1855544.yml
+++ b/tests/tests_bz1855544.yml
@@ -8,6 +8,7 @@
       vars:
         metrics_query_service: yes
         metrics_graph_service: yes
+        metrics_from_bpftrace: yes
 
   pre_tasks:
     - meta: end_host

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: MIT
+---
+
+__metrics_domains: []
+__metrics_accounts: {}


### PR DESCRIPTION
Tackle a number of issues Jan has uncovered in testing:
- remove recursion between the higher and lower level roles
- the bpftrace, elasticsearch and mssql agent installations
  are performed via single pcp role invocation from metrics
- fix incorrect macro name for sasl authentication packages
- fix incorrect macro name for sasl user names
- fix incorrect invocation of saslpasswd2
- added some more example playbooks

Small cleanups and inconsistencies throughout corrected also.
New sub-roles now also get a metric_provider variable passed
in to allow for alternate (and/or minimal) implementations.

Resolves https://github.com/linux-system-roles/metrics/issues/47
Resolves https://github.com/linux-system-roles/metrics/issues/46
Resolves https://github.com/linux-system-roles/metrics/issues/34
Resolves https://github.com/linux-system-roles/metrics/issues/33