### PR TITLE
Fix of misspelled "Elasticsearch"

### DIFF
--- a/tests/check_into_elasticsearch.yml
+++ b/tests/check_into_elasticsearch.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Check if export to ElasticSearch is installed
+- name: Check if export to Elasticsearch is installed
   command: test -x /usr/bin/pcp2elasticsearch

--- a/tests/tests_sanity_from_elasticsearch.yml
+++ b/tests/tests_sanity_from_elasticsearch.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Test import from ElasticSearch
+- name: Test import from Elasticsearch
   hosts: all
 
   roles:
@@ -18,7 +18,7 @@
       import_tasks: get_services_state.yml
 
   tasks:
-    - name: Check if import from Elastic Search works
+    - name: Check if import from Elasticsearch works
       include_tasks: check_from_elasticsearch.yml
 
   post_tasks:

--- a/tests/tests_sanity_into_elasticsearch.yml
+++ b/tests/tests_sanity_into_elasticsearch.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Test import to Elastic Search
+- name: Test import to Elasticsearch
   hosts: all
 
   roles:
@@ -18,7 +18,7 @@
       import_tasks: get_services_state.yml
 
   tasks:
-    - name: Check if import to Elastic Search works
+    - name: Check if import to Elasticsearch works
       include_tasks: check_into_elasticsearch.yml
 
   post_tasks:


### PR DESCRIPTION
Fix of misspelled Elasticsearch name as commented in https://github.com/linux-system-roles/metrics/pull/59#pullrequestreview-581550920