### PR TITLE
Update mssql test to exclude non-x86_64 architectures

### DIFF
--- a/tests/tests_sanity_mssql.yml
+++ b/tests/tests_sanity_mssql.yml
@@ -12,7 +12,8 @@
     - meta: end_host
       when: (ansible_distribution in ['RedHat'] and
              ( ansible_facts['distribution_version'] is version('8.4', '<'))) or
-             ansible_distribution not in ['Fedora', 'RedHat']
+             ansible_distribution not in ['Fedora', 'RedHat'] or
+             ansible_architecture not in ['x86_64']
 
     - name: Save state of services
       import_tasks: get_services_state.yml


### PR DESCRIPTION
pcp-pmda-mssql (and SQL Server itself) are x86_64-only.