### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
         - 6
         - 7
         - 8
+        - 9
 
   galaxy_tags: []
   # List tags for your role here, one per line. A tag is a keyword that


### PR DESCRIPTION
From now the rhel-8-y status is the latest unreleased RHEL-8 and the rhel-x status is pre-released RHEL-9.