### PR TITLE
RHELPLAN-68122 - Collections - Metrics - fixing ansible-test errors

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.2.1"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.3.0"
   LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
   LSR_MSCENARIOS: default
   # LSR_EXTRA_PACKAGES: libdbus-1-dev
@@ -37,7 +37,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection,ansible-test" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -1,0 +1,6 @@
+tests/metrics/roles/bpftrace symlinks
+tests/metrics/roles/elasticsearch symlinks
+tests/metrics/roles/grafana symlinks
+tests/metrics/roles/mssql symlinks
+tests/metrics/roles/pcp symlinks
+tests/metrics/roles/redis symlinks

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,6 @@
+tests/metrics/roles/bpftrace symlinks
+tests/metrics/roles/elasticsearch symlinks
+tests/metrics/roles/grafana symlinks
+tests/metrics/roles/mssql symlinks
+tests/metrics/roles/pcp symlinks
+tests/metrics/roles/redis symlinks


### PR DESCRIPTION
- Add .sanity-ansible-ignore-2.{9,10}.txt to skip ansible-test symlinks test.
- Use tox-lsr 2.3.0 and enable ansible-test
    - Upgrade to tox-lsr 2.3.0 which fixes several issues with running
      ansible-test sanity from tox.
    - Add ansible-test to the python 3.6 test list.