### PR TITLE
Partial Revert "RHELPLAN-68122 - Collections - Metrics - fixing ansible-test errors"

### DIFF
--- a/.sanity-ansible-ignore-2.10.txt
+++ b/.sanity-ansible-ignore-2.10.txt
@@ -1,6 +1,0 @@
-tests/metrics/roles/bpftrace symlinks
-tests/metrics/roles/elasticsearch symlinks
-tests/metrics/roles/grafana symlinks
-tests/metrics/roles/mssql symlinks
-tests/metrics/roles/pcp symlinks
-tests/metrics/roles/redis symlinks

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,6 +1,0 @@
-tests/metrics/roles/bpftrace symlinks
-tests/metrics/roles/elasticsearch symlinks
-tests/metrics/roles/grafana symlinks
-tests/metrics/roles/mssql symlinks
-tests/metrics/roles/pcp symlinks
-tests/metrics/roles/redis symlinks


### PR DESCRIPTION
This reverts "Add .sanity-ansible-ignore-2.{9,10}.txt to skip ansible-test
symlinks test" part of commit edbc854ae7c795764051da907314903127668251.

To make ansible-test pass, instead of ignoring the symlinks in tests/roles
using the ignore file .sanity-ansible-ignore-#.#.txt, make the collection
conversion tool lsr_role2collection.py clean the symlinks up [0]. With
the change, we can get rid of .sanity-ansible-ignore-#.#.txt.

[0] - https://github.com/linux-system-roles/auto-maintenance/pull/54