### PR TITLE
Revert accidental inclusion of var path from the spark role

### DIFF
--- a/roles/spark/vars/RedHat_9.yml
+++ b/roles/spark/vars/RedHat_9.yml
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-# Put internal variables here with Red Hat Enterprise Linux 9 specific values.
-
-__spark_packages_export_pcp:
-  - pcp-export-pcp2spark
-  - pcp-system-tools


### PR DESCRIPTION
Commit 10ac5c7b introduced this when it should not have.