### PR TITLE
check_redis should use shell not command

### DIFF
--- a/tests/check_redis.yml
+++ b/tests/check_redis.yml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Check if Redis responds
-  command: redis-cli PING | grep PONG
+  shell: |
+    set -euo pipefail
+    redis-cli PING | grep PONG


### PR DESCRIPTION
the redis_cli check was silently failing - it reported an error
that the `|` argument was invalid, but it returned a 0 exit code
anyway.  You cannot use pipes `|` or other bash constructs using
the `command` module, you must use the `shell` module.