### PR TITLE
[citest skip] make min_ansible_version a string in meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   company: Red Hat, Inc.
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
 
   # If this is a Container Enabled role, provide the minimum Ansible Container
   # version.


### PR DESCRIPTION
The Ansible developers say that `min_ansible_version` in meta/main.yml
must be a `string` value like `"2.9"`, not a `float` value like `2.9`.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
