### PR TITLE
[citest skip] Fix a bug in changelog_to_tag.yml

### DIFF
--- a/.github/workflows/changelog_to_tag.yml
+++ b/.github/workflows/changelog_to_tag.yml
@@ -31,7 +31,8 @@ jobs:
                   echo "$line"
               fi
           done > ./.tagmsg.txt
-          _tagname=$( grep -m 1 "[0-9]*\.[0-9]*\.[0-9]*" CHANGELOG.md | sed -e "s/^.*\[\([0-9]*\.[0-9]*\.[0-9]*\)\].*/\1/" )
+          _tagname=$( grep -m 1 "[0-9]*\.[0-9]*\.[0-9]*" CHANGELOG.md | \
+                      sed -e "s/^.*\[\([0-9]*\.[0-9]*\.[0-9]*\)\].*/\1/" )
           git fetch --all --tags
           for t in $( git tag -l ); do
               if [[ $t == "$_tagname" ]]; then
@@ -39,7 +40,11 @@ jobs:
                   exit 1
               fi
           done
+          # Get the main branch name, "master" or "main".
+          _branch=$( git branch -r | grep -o 'origin/HEAD -> origin/.*$' | \
+                     awk -F'/' '{print $3}' )
           echo ::set-output name=tagname::"$_tagname"
+          echo ::set-output name=branch::"$_branch"
       - name: Create tag
         uses: mathieudutour/github-tag-action@v6.0
         with:
@@ -59,3 +64,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.0
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          git_branch: ${{ steps.tag.outputs.branch }}


### PR DESCRIPTION
"Publish role to Galaxy" step needs to specify git_branch if the
main branch is other than "master". This bug was introduced by
the PR: Add "Publish role to Galaxy" to github action changelog_
to_tag.yml.