### PR TITLE
Use the firewall role and the selinux role from the metrics role

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ on the managed host.
 The role can optionally use Grafana v6+ (`metrics_graph_service`) and
 Redis v5+ (`metrics_query_service`) on Fedora, CentOS 8, RHEL 8 and later.
 
+The role requires the `firewall` role and the `selinux` role from the
+`fedora.linux_system_roles` collection, if `metrics_manage_firewall`
+and `metrics_manage_selinux` is set to true, respectively.
+(Please see also the variables in the [`Role Variables`](#role-variables) section.)
+
+If the `metrics` is a role from the `fedora.linux_system_roles`
+collection or from the Fedora RPM package, the requirement is already
+satisfied.
+
+Otherwise, please run the following command line to install the collection.
+```
+ansible-galaxy collection install -r meta/collection-requirements.yml
+```
+
 ## Role Variables
 
     metrics_monitored_hosts: []
@@ -84,17 +98,41 @@ live metric value sampling), 44322 (pmproxy, with metrics_query_service
 or metrics_graph_service), 6379 (redis-server for metrics_query_service)
 and 3000 (grafana-server for metrics_graph_service).
 
-This role does not configure for remote access to these services such as
-through a firewall.  See https://github.com/linux-system-roles/firewall
+    metrics_manage_firewall: false
 
-This role does not configure SELinux for remote access to these services
-either.  However, the pmcd and pmproxy services are in the "ephemeral"
+Boolean flag allowing to configure firewall using the firewall role.
+Manage the pmcd port, the pmproxy port, the Grafana port and the Redis
+port depending upon the configuration parameters.
+If the variable is set to false, the `metrics role` does not manage the
+firewall.
+
+NOTE: `metrics_manage_firewall` is limited to *adding* ports.
+It cannot be used for *removing* ports.
+If you want to remove ports, you will need to use the firewall system
+role directly.
+
+NOTE: the firewall management is not supported on RHEL 6.
+
+    metrics_manage_selinux: false
+
+Boolean flag allowing to configure selinux using the selinux role.
+Assign the pmcd port, the pmproxy port, the Grafana port and the Redis
+port depending upon the configuration parameters.
+If the variable is set to false, the `metrics role` does not manage the
+selinux.
+
+Please note that the pmcd and pmproxy services are in the "ephemeral"
 range requiring no special setup and the Grafana port is "unregistered".
 The Redis port is gated by the redis_port_t SELinux type and may need to
 be further configured, if you require direct access (not required if you
 are accessing it from metrics role tools like Grafana and PCP).
 Use https://github.com/linux-system-roles/selinux to manage port access,
 for SELinux contexts.
+
+NOTE: `metrics_manage_selinux` is limited to *adding* policy.
+It cannot be used for *removing* policy.
+If you want to remove policy, you will need to use the selinux system
+role directly.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,12 @@ metrics_password: metrics
 
 # Default metrics provider is PCP
 metrics_provider: pcp
+
+# If true, manage the pmcd port, pmproxy ports, grafana service and
+# redis service using the firewall role depending upon the configuration
+# parameters.
+metrics_manage_firewall: false
+
+# If true, manage the pmcd port, pmproxy ports using the selinux role
+# depending upon the configuration parameters.
+metrics_manage_selinux: false

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: MIT
+collections:
+  - fedora.linux_system_roles

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+---
+- block:
+    - name: Initialize __metrics_firewall
+      set_fact:
+        __metrics_firewall: []
+
+    - name: Port for pmcd
+      set_fact:
+        __metrics_firewall:
+          - {'port': '44321/tcp', 'state': 'enabled' }
+      when: metrics_provider == 'pcp'
+
+    - name: Port for pmproxy used by query and grafana
+      set_fact:
+        __metrics_firewall: "{{ __metrics_firewall |
+            union([{'port': '44322/tcp', 'state': 'enabled'}]) }}"
+      when:
+        - metrics_graph_service|bool or metrics_query_service|bool
+
+    - name: service for grafana
+      set_fact:
+        __metrics_firewall: "{{ __metrics_firewall |
+            union([{'service': 'grafana', 'state': 'enabled'}]) }}"
+      when:
+        - metrics_graph_service|bool
+
+    - name: service for redis
+      set_fact:
+        __metrics_firewall: "{{ __metrics_firewall |
+            union([{'service': 'redis', 'state': 'enabled'}]) }}"
+      when:
+        - metrics_query_service|bool
+
+    - name: Ensure the service and the port status with the firewall role
+      include_role:
+        name: fedora.linux_system_roles.firewall
+      vars:
+        firewall: "{{ __metrics_firewall }}"
+  when:
+    - metrics_manage_firewall | bool
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_version'] is version('7', '>=')

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
     redis_metrics_provider: "{{ metrics_provider }}"
   include_role:
     name: "{{ role_path }}/roles/redis"
-  when: metrics_query_service|d(false)|bool
+  when: metrics_query_service|bool
 
 - name: Setup metric collection service.
   vars:
@@ -78,8 +78,8 @@
     pcp_target_hosts: "{{ metrics_monitored_hosts }}"
     pcp_optional_agents: "{{ __metrics_domains }}"
     pcp_accounts: "{{ __metrics_accounts }}"
-    pcp_rest_api: "{{ metrics_query_service|d(false)|bool or
-                      metrics_graph_service|d(false)|bool }}"
+    pcp_rest_api: "{{ metrics_query_service|bool or
+                      metrics_graph_service|bool }}"
   include_role:
     name: "{{ role_path }}/roles/pcp"
   when: metrics_provider == 'pcp'
@@ -89,4 +89,10 @@
     grafana_metrics_provider: "{{ metrics_provider }}"
   include_role:
     name: "{{ role_path }}/roles/grafana"
-  when: metrics_graph_service|d(false)|bool
+  when: metrics_graph_service|bool
+
+- name: Configure firewall
+  include_tasks: firewall.yml
+
+- name: Configure selinux
+  include_tasks: selinux.yml

--- a/tasks/selinux.yml
+++ b/tasks/selinux.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+---
+- block:
+    - name: Set pcp_bind_all_unreserved_ports
+      set_fact:
+        __metrics_selinux:
+          - [{name: 'pcp_bind_all_unreserved_ports', state: 'on'}]
+
+    - name: Ensure the port status with the selinux role
+      include_role:
+        name: fedora.linux_system_roles.selinux
+      vars:
+        selinux_booleans: "{{ __metrics_selinux }}"
+  when:
+    - metrics_manage_selinux | bool

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+---
+# Assume firewalld and selinux are not manually configured.
+- block:
+    - name: "Check firewall service status for grafana;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-services
+      register: _result
+      failed_when:
+        - "'grafana' not in _result.stdout"
+      changed_when: false
+      when:
+        - metrics_graph_service|d(false)|bool
+
+    - name: "Check firewall service status for redis;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-services
+      register: _result
+      failed_when: "'redis' not in _result.stdout"
+      changed_when: false
+      when:
+        - metrics_query_service|d(false)|bool
+
+    - name: "Check firewall port status for pmproxy;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-ports
+      register: _result
+      failed_when:
+        - "'44322/tcp' not in _result.stdout"
+      changed_when: false
+      when:
+        - metrics_graph_service|d(false)|bool or
+          metrics_query_service|d(false)|bool
+
+    - name: "Check firewall port status for pmcd;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-ports
+      register: _result
+      failed_when: "'44321/tcp' not in _result.stdout"
+      changed_when: false
+  when:
+    - metrics_provider == 'pcp'
+    - ansible_facts['os_family'] == 'RedHat'
+    - ansible_facts['distribution_version'] is version('7', '>=')
+    - metrics_manage_firewall | bool
+
+- name: Check associated selinux ports (metrics_manage_selinux is true)
+  shell: |-
+    set -euo pipefail
+    semanage boolean --list | egrep "pcp_bind_all_unreserved_ports *\(on "
+  changed_when: false
+  when: metrics_manage_selinux | bool

--- a/tests/tests_sanity_auth.yml
+++ b/tests/tests_sanity_auth.yml
@@ -11,6 +11,9 @@
       vars:
         metrics_username: "{{ __test_uname }}"
         metrics_password: "{{ __test_pswd }}"
+        # test to install firewall but not selinux
+        metrics_manage_firewall: true
+        metrics_manage_selinux: false
 
   pre_tasks:
     - meta: end_host
@@ -30,6 +33,7 @@
       include_tasks: "{{ item }}"
       loop:
         - check_sasl.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_basic.yml
+++ b/tests/tests_sanity_basic.yml
@@ -5,6 +5,10 @@
 
   roles:
     - role: linux-system-roles.metrics
+      vars:
+        # test to install selinux but not firewall
+        metrics_manage_firewall: false
+        metrics_manage_selinux: true
 
   pre_tasks:
     - name: Save state of services
@@ -17,6 +21,7 @@
         - check_pcp.yml
         - check_pmlogger.yml
         - check_pmie.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_bpftrace.yml
+++ b/tests/tests_sanity_bpftrace.yml
@@ -12,6 +12,9 @@
         metrics_from_bpftrace: yes
         metrics_username: "{{ __test_uname }}"
         metrics_password: "{{ __test_pswd }}"
+        # test not to install selinux and firewall, explicitly
+        metrics_manage_firewall: false
+        metrics_manage_selinux: false
 
   pre_tasks:
     - meta: end_host
@@ -28,6 +31,7 @@
       loop:
         - check_bpftrace.yml
         - check_sasl.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_fullstack.yml
+++ b/tests/tests_sanity_fullstack.yml
@@ -8,6 +8,8 @@
       vars:
         metrics_query_service: yes
         metrics_graph_service: yes
+        metrics_manage_firewall: true
+        metrics_manage_selinux: true
 
   pre_tasks:
     - meta: end_host
@@ -29,6 +31,7 @@
         - check_pmproxy.yml
         - check_grafana.yml
         - check_grafanapcp.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_graph.yml
+++ b/tests/tests_sanity_graph.yml
@@ -23,6 +23,7 @@
       loop:
         - check_grafana.yml
         - check_grafanapcp.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_mssql.yml
+++ b/tests/tests_sanity_mssql.yml
@@ -28,6 +28,7 @@
       include_tasks: "{{ item }}"
       loop:
         - check_mssql.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_postfix.yml
+++ b/tests/tests_sanity_postfix.yml
@@ -43,6 +43,7 @@
       include_tasks: "{{ item }}"
       loop:
         - check_postfix.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_query.yml
+++ b/tests/tests_sanity_query.yml
@@ -26,6 +26,7 @@
         - check_pmie.yml
         - check_redis.yml
         - check_pmproxy.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services

--- a/tests/tests_sanity_retention.yml
+++ b/tests/tests_sanity_retention.yml
@@ -22,6 +22,7 @@
         - check_pmlogger.yml
         - check_pmie.yml
         - check_retention.yml
+        - check_firewall_selinux.yml
 
   post_tasks:
     - name: Restore state of services


### PR DESCRIPTION
- Introduce metrics_manage_firewall to use the firewall role to
  manage the pmcd port, the pmproxy ports, the grafana port and
  the redis port depending upon the configuration parameters.
  metrics_manage_firewall is set to true, by default.

- Introduce metrics_manage_selinux to use the selinux role to
  manage the pmcd port, the pmproxy ports, the grafana port and
  the redis port depending upon the configuration parameters.
  If the variable is set to false, the selinux configuration is
  disabled.

- Add the test check task check_firewall_selinux.yml for verify
  the ports status.

- Add meta/collection-requirements.yml