### PR TITLE
ci: update metrics ansible-lint; add ha_cluster to python_roles

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,10 +15,18 @@ kinds:
 skip_list:
   - fqcn-builtins
   - galaxy[no-changelog]
-  - meta-unsupported-ansible
 exclude_paths:
   - tests/roles/
   - .github/
   - examples/roles/
 mock_roles:
   - linux-system-roles.metrics
+  - performancecopilot.metrics.bpftrace
+  - performancecopilot.metrics.elasticsearch
+  - performancecopilot.metrics.grafana
+  - performancecopilot.metrics.mssql
+  - performancecopilot.metrics.pcp
+  - performancecopilot.metrics.postfix
+  - performancecopilot.metrics.redis
+  - performancecopilot.metrics.repository
+  - performancecopilot.metrics.spark


### PR DESCRIPTION
ha_cluster - add to python_roles

metrics - fix ansible-lint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
