### PR TITLE
fix: make role work on ansible-core 2.15

### DIFF
--- a/tests/tests_bz1855539.yml
+++ b/tests/tests_bz1855539.yml
@@ -3,12 +3,12 @@
 - name: "Bug 1855539 - metrics role incorrectly sets up multiple primary
          pmie processes in multi-host mode"
   hosts: all
-
+  vars:
+    pcp_pmie_control_path: "/etc/pcp/pmie/control.d/"
   roles:
     - role: linux-system-roles.metrics
       vars:
         metrics_monitored_hosts: ["127.0.0.2", "127.0.0.3"]
-        pcp_pmie_control_path: "/etc/pcp/pmie/control.d/"
 
   pre_tasks:
     - name: Stop test


### PR DESCRIPTION
I guess ansible-core 2.15 does not export `vars` defined
in a `roles` keyword in a play to other task sections in
the play.  The fix is to declare the variable in the `vars`
at the `play` level.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
