### PR TITLE
ci: ansible-lint - ignore var-naming[no-role-prefix]

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,6 +14,7 @@ kinds:
   - playbook: "**/examples/*.yml"
 skip_list:
   - fqcn-builtins
+  - var-naming[no-role-prefix]
   - galaxy[no-changelog]
 exclude_paths:
   - tests/roles/


### PR DESCRIPTION
ansible-lint has recently added a check for this.  It flags a lot of our test
code, and some of our role code that uses nested roles.
There is no easy way to disable it for these cases only.  It would be a
tremendous amount of work to add `# noqa` comments everywhere.
The use of `.ansible-lint-ignore` would be a maintenance burden (cannot use
tests/tests_*.yml or other similar wildcard to match all test files), would
still issue a lot of warning messages, and would not solve all of the problems.
The only way for now is to skip this rule.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
