### PR TITLE
feat: support for ostree systems

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -32,3 +32,5 @@ mock_roles:
   - performancecopilot.metrics.redis
   - performancecopilot.metrics.repository
   - performancecopilot.metrics.spark
+mock_modules:
+  - ansible.utils.update_fact

--- a/.ostree/README.md
+++ b/.ostree/README.md
@@ -1,0 +1,3 @@
+*NOTE*: The `*.txt` files are used by `get_ostree_data.sh` to create the lists
+of packages, and to find other system roles used by this role.  DO NOT use them
+directly.

--- a/.ostree/get_ostree_data.sh
+++ b/.ostree/get_ostree_data.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -euo pipefail
+
+role_collection_dir="${ROLE_COLLECTION_DIR:-fedora/linux_system_roles}"
+ostree_dir="${OSTREE_DIR:-"$(dirname "$(realpath "$0")")"}"
+
+if [ -z "${4:-}" ] || [ "${1:-}" = help ] || [ "${1:-}" = -h ]; then
+    cat <<EOF
+Usage: $0 packages [runtime|testing] DISTRO-MAJOR[.MINOR] [json|yaml|raw|toml]
+The script will use the packages and roles files in $ostree_dir to
+construct the list of packages needed to build the ostree image.  The script
+will output the list of packages in the given format
+- json is a JSON list like ["pkg1","pkg2",....,"pkgN"]
+- yaml is the YAML list format
+- raw is the list of packages, one per line
+- toml is a list of [[packages]] elements as in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line
+The DISTRO-MAJOR.MINOR is the same format used by Ansible for distribution e.g. CentOS-8, RedHat-8.9, etc.
+EOF
+    exit 1
+fi
+category="$1"
+pkgtype="$2"
+distro_ver="$3"
+format="$4"
+pkgtypes=("$pkgtype")
+if [ "$pkgtype" = testing ]; then
+    pkgtypes+=(runtime)
+fi
+
+get_rolepath() {
+    local ostree_dir role rolesdir roles_parent_dir
+    ostree_dir="$1"
+    role="$2"
+    roles_parent_dir="$(dirname "$(dirname "$ostree_dir")")"
+    rolesdir="$roles_parent_dir/$role/.ostree"
+    # assumes collection format
+    if [ -d "$rolesdir" ]; then
+        echo "$rolesdir"
+        return 0
+    fi
+    # assumes legacy role format like linux-system-roles.$role/
+    for rolesdir in "$roles_parent_dir"/*-system-roles."$role"/.ostree; do
+        if [ -d "$rolesdir" ]; then
+          echo "$rolesdir"
+          return 0
+        fi
+    done
+    # look elsewhere
+    if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
+        for pth in ${ANSIBLE_COLLECTIONS_PATHS//:/ }; do
+            rolesdir="$pth/ansible_collections/$role_collection_dir/roles/$role/.ostree"
+            if [ -d "$rolesdir" ]; then
+                echo "$rolesdir"
+                return 0
+            fi
+        done
+    fi
+    return 1
+}
+
+get_packages() {
+    local ostree_dir pkgtype pkgfile rolefile
+    ostree_dir="$1"
+    for pkgtype in "${pkgtypes[@]}"; do
+        for suff in "" "-$distro" "-${distro}-${major_ver}" "-${distro}-${ver}"; do
+            pkgfile="$ostree_dir/packages-${pkgtype}${suff}.txt"
+            if [ -f "$pkgfile" ]; then
+                cat "$pkgfile"
+            fi
+        done
+        rolefile="$ostree_dir/roles-${pkgtype}.txt"
+        if [ -f "$rolefile" ]; then
+            local roles role rolepath
+            roles="$(cat "$rolefile")"
+            for role in $roles; do
+                rolepath="$(get_rolepath "$ostree_dir" "$role")"
+                get_packages "$rolepath"
+            done
+        fi
+    done | sort -u
+}
+
+format_packages_json() {
+    local comma pkgs pkg
+    comma=""
+    pkgs="["
+    while read -r pkg; do
+        pkgs="${pkgs}${comma}\"${pkg}\""
+        comma=,
+    done
+    pkgs="${pkgs}]"
+    echo "$pkgs"
+}
+
+format_packages_raw() {
+    cat
+}
+
+format_packages_yaml() {
+    while read -r pkg; do
+        echo "- $pkg"
+    done
+}
+
+format_packages_toml() {
+    while read -r pkg; do
+        echo "[[packages]]"
+        echo "name = \"$pkg\""
+        echo "version = \"*\""
+    done
+}
+
+distro="${distro_ver%%-*}"
+ver="${distro_ver##*-}"
+if [[ "$ver" =~ ^([0-9]*) ]]; then
+    major_ver="${BASH_REMATCH[1]}"
+else
+    echo ERROR: cannot parse major version number from version "$ver"
+    exit 1
+fi
+
+"get_$category" "$ostree_dir" | "format_${category}_$format"

--- a/.ostree/packages-runtime-CentOS-8.txt
+++ b/.ostree/packages-runtime-CentOS-8.txt
@@ -1,0 +1,5 @@
+bpftrace
+grafana
+pcp-pmda-bpftrace
+redis
+redis-doc

--- a/.ostree/packages-runtime-Fedora.txt
+++ b/.ostree/packages-runtime-Fedora.txt
@@ -1,0 +1,10 @@
+bpftrace
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-mssql
+pcp-system-tools
+redis
+redis-doc
+RediSearch

--- a/.ostree/packages-runtime-RedHat-8.txt
+++ b/.ostree/packages-runtime-RedHat-8.txt
@@ -1,0 +1,9 @@
+bpftrace
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-mssql
+pcp-system-tools
+redis
+redis-doc

--- a/.ostree/packages-runtime-RedHat-9.txt
+++ b/.ostree/packages-runtime-RedHat-9.txt
@@ -1,0 +1,9 @@
+bpftrace
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-mssql
+pcp-system-tools
+redis
+redis-doc

--- a/.ostree/packages-runtime.txt
+++ b/.ostree/packages-runtime.txt
@@ -1,0 +1,6 @@
+cyrus-sasl-lib
+cyrus-sasl-scram
+pcp
+pcp-pmda-elasticsearch
+pcp-pmda-postfix
+pcp-zeroconf

--- a/.ostree/packages-testing-CentOS-8.txt
+++ b/.ostree/packages-testing-CentOS-8.txt
@@ -1,0 +1,5 @@
+bpftrace
+grafana
+pcp-pmda-bpftrace
+redis
+redis-doc

--- a/.ostree/packages-testing-CentOS.txt
+++ b/.ostree/packages-testing-CentOS.txt
@@ -1,0 +1,6 @@
+cyrus-sasl-scram
+pcp-pmda-elasticsearch
+pcp-pmda-postfix
+pcp-zeroconf
+postfix
+postfix-perl-scripts

--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -1,0 +1,17 @@
+bpftrace
+cyrus-sasl-scram
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-elasticsearch
+pcp-pmda-mssql
+pcp-pmda-postfix
+pcp-system-tools
+pcp-zeroconf
+postfix
+postfix-perl-scripts
+python3-pyodbc
+redis
+redis-doc
+RediSearch

--- a/.ostree/packages-testing-RedHat-6.txt
+++ b/.ostree/packages-testing-RedHat-6.txt
@@ -1,0 +1,4 @@
+cyrus-sasl-md5
+pcp-pmda-dm
+pcp-pmda-nfsclient
+pcp-system-tools

--- a/.ostree/packages-testing-RedHat-7.txt
+++ b/.ostree/packages-testing-RedHat-7.txt
@@ -1,0 +1,6 @@
+cyrus-sasl-scram
+pcp-pmda-elasticsearch
+pcp-pmda-postfix
+pcp-zeroconf
+postfix
+postfix-perl-scripts

--- a/.ostree/packages-testing-RedHat-8.txt
+++ b/.ostree/packages-testing-RedHat-8.txt
@@ -1,0 +1,16 @@
+bpftrace
+cyrus-sasl-scram
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-elasticsearch
+pcp-pmda-mssql
+pcp-pmda-postfix
+pcp-system-tools
+pcp-zeroconf
+postfix
+postfix-perl-scripts
+python3-pyodbc
+redis
+redis-doc

--- a/.ostree/packages-testing-RedHat-9.txt
+++ b/.ostree/packages-testing-RedHat-9.txt
@@ -1,0 +1,16 @@
+bpftrace
+cyrus-sasl-scram
+grafana
+grafana-pcp
+pcp-export-pcp2elasticsearch
+pcp-pmda-bpftrace
+pcp-pmda-elasticsearch
+pcp-pmda-mssql
+pcp-pmda-postfix
+pcp-system-tools
+pcp-zeroconf
+postfix
+postfix-perl-scripts
+python3-pyodbc
+redis
+redis-doc

--- a/.ostree/packages-testing.txt
+++ b/.ostree/packages-testing.txt
@@ -1,0 +1,2 @@
+cyrus-sasl-lib
+pcp

--- a/.ostree/roles-runtime.txt
+++ b/.ostree/roles-runtime.txt
@@ -1,0 +1,2 @@
+firewall
+selinux

--- a/.sanity-ansible-ignore-2.12.txt
+++ b/.sanity-ansible-ignore-2.12.txt
@@ -1,0 +1,1 @@
+roles/metrics/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.13.txt
+++ b/.sanity-ansible-ignore-2.13.txt
@@ -1,0 +1,1 @@
+roles/metrics/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.14.txt
+++ b/.sanity-ansible-ignore-2.14.txt
@@ -1,0 +1,1 @@
+roles/metrics/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.15.txt
+++ b/.sanity-ansible-ignore-2.15.txt
@@ -1,0 +1,1 @@
+roles/metrics/.ostree/get_ostree_data.sh shebang!skip

--- a/.sanity-ansible-ignore-2.9.txt
+++ b/.sanity-ansible-ignore-2.9.txt
@@ -1,0 +1,1 @@
+roles/metrics/.ostree/get_ostree_data.sh shebang!skip

--- a/README-ostree.md
+++ b/README-ostree.md
@@ -1,0 +1,66 @@
+# rpm-ostree
+
+The role supports running on [rpm-ostree](https://coreos.github.io/rpm-ostree/)
+systems. The primary issue is that the `/usr` filesystem is read-only, and the
+role cannot install packages. Instead, it will just verify that the necessary
+packages and any other `/usr` files are pre-installed. The role will change the
+package manager to one that is compatible with `rpm-ostree` systems.
+
+## Building
+
+To build an ostree image for a particular operating system distribution and
+version, use the script `.ostree/get_ostree_data.sh` to get the list of
+packages. If the role uses other system roles, then the script will include the
+packages for the other roles in the list it outputs.  The list of packages will
+be sorted in alphanumeric order.
+
+Usage:
+
+```bash
+.ostree/get_ostree_data.sh packages runtime DISTRO-VERSION FORMAT
+```
+
+`DISTRO-VERSION` is in the format that Ansible uses for `ansible_distribution`
+and `ansible_distribution_version` - for example, `Fedora-38`, `CentOS-8`,
+`RedHat-9.4`
+
+`FORMAT` is one of `toml`, `json`, `yaml`, `raw`
+
+* `toml` - each package in a TOML `[[packages]]` element
+
+```toml
+[[packages]]
+name = "package-a"
+version = "*"
+[[packages]]
+name = "package-b"
+version = "*"
+...
+```
+
+* `yaml` - a YAML list of packages
+
+```yaml
+- package-a
+- package-b
+...
+```
+
+* `json` - a JSON list of packages
+
+```json
+["package-a","package-b",...]
+```
+
+* `raw` - a plain text list of packages, one per line
+
+```bash
+package-a
+package-b
+...
+```
+
+What format you choose depends on which image builder you are using.  For
+example, if you are using something based on
+[osbuild-composer](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#creating-an-image-builder-blueprint-for-a-rhel-for-edge-image-using-the-command-line-interface_composing-a-rhel-for-edge-image-using-image-builder-command-line),
+you will probably want to use the `toml` output format.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ If the `metrics` is a role from the `fedora.linux_system_roles`
 collection or from the Fedora RPM package, the requirement is already
 satisfied.
 
-Otherwise, please run the following command line to install the collection.
+The role requires additional collections to manage `rpm-ostree` systems.
+If you need to manage `rpm-ostree` systems, run the below command to
+install the collections.
 
 ```bash
 ansible-galaxy collection install -r meta/collection-requirements.yml
@@ -191,6 +193,10 @@ endpoint, graphs and scalable querying.
   roles:
     - linux-system-roles.metrics
 ```
+
+## rpm-ostree
+
+See README-ostree.md
 
 ## License
 

--- a/meta/collection-requirements.yml
+++ b/meta/collection-requirements.yml
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
 collections:
+  - ansible.posix
+  - ansible.utils
   - fedora.linux_system_roles

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,29 @@
 # SPDX-License-Identifier: MIT
 ---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: "{{ __metrics_required_facts_subsets }}"
+  when: __metrics_required_facts |
+    difference(ansible_facts.keys() | list) | length > 0
+
+- name: Ensure correct package manager for ostree systems
+  vars:
+    ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+    ostree_booted_file: /run/ostree-booted
+  when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: "{{ ostree_booted_file }}"
+      register: __ostree_booted_stat
+
+    - name: Set package manager to use for ostree
+      ansible.utils.update_fact:
+        updates:
+          - path: ansible_facts.pkg_mgr
+            value: "{{ ostree_pkg_mgr }}"
+      when: __ostree_booted_stat.stat.exists
+
 - name: Add Elasticsearch to metrics domain list
   set_fact:
     __metrics_domains: "{{ __metrics_domains + ['elasticsearch'] }}"

--- a/tests/check_into_elasticsearch.yml
+++ b/tests/check_into_elasticsearch.yml
@@ -6,5 +6,6 @@
 
 - name: Check the ansible_managed header in pcp2elasticsearch.service
   vars:
-    __test_config_path: /usr/lib/systemd/system/pcp2elasticsearch.service
+    __test_config_path: >-
+      {{ __elasticsearch_service_path }}/pcp2elasticsearch.service
   include_tasks: check_header.yml

--- a/tests/tests_verify_from_elasticsearch.yml
+++ b/tests/tests_verify_from_elasticsearch.yml
@@ -3,11 +3,6 @@
 - name: Test import from Elasticsearch
   hosts: all
 
-  roles:
-    - role: linux-system-roles.metrics
-      vars:
-        metrics_from_elasticsearch: true
-
   pre_tasks:
     - name: Stop test
       meta: end_host
@@ -19,6 +14,13 @@
       import_tasks: get_services_state.yml
 
   tasks:
+    - name: Run the metrics role to configure Elasticsearch
+      include_role:
+        name: linux-system-roles.metrics
+        public: true
+      vars:
+        metrics_from_elasticsearch: true
+
     - name: Check if import from Elasticsearch works
       include_tasks: check_from_elasticsearch.yml
 

--- a/tests/tests_verify_mssql.yml
+++ b/tests/tests_verify_mssql.yml
@@ -19,6 +19,24 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
+    - name: Ensure correct package manager for ostree systems
+      vars:
+        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+        ostree_booted_file: /run/ostree-booted
+      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: "{{ ostree_booted_file }}"
+          register: __ostree_booted_stat
+
+        - name: Set package manager to use for ostree
+          ansible.utils.update_fact:
+            updates:
+              - path: ansible_facts.pkg_mgr
+                value: "{{ ostree_pkg_mgr }}"
+          when: __ostree_booted_stat.stat.exists
+
     - name: Ensure python3-pyodbc is installed
       package:
         name: python3-pyodbc

--- a/tests/tests_verify_postfix.yml
+++ b/tests/tests_verify_postfix.yml
@@ -18,6 +18,24 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
+    - name: Ensure correct package manager for ostree systems
+      vars:
+        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
+        ostree_booted_file: /run/ostree-booted
+      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: "{{ ostree_booted_file }}"
+          register: __ostree_booted_stat
+
+        - name: Set package manager to use for ostree
+          ansible.utils.update_fact:
+            updates:
+              - path: ansible_facts.pkg_mgr
+                value: "{{ ostree_pkg_mgr }}"
+          when: __ostree_booted_stat.stat.exists
+
     - name: Ensure postfix is installed
       package:
         name:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,15 @@
 
 __metrics_domains: []
 __metrics_accounts: {}
+
+__metrics_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family
+
+# the subsets of ansible_facts that need to be gathered in case any of the
+# facts in required_facts is missing; see the documentation of
+# the 'gather_subset' parameter of the 'setup' module
+__metrics_required_facts_subsets: "{{ ['!all', '!min'] +
+  __metrics_required_facts }}"


### PR DESCRIPTION
Feature: Allow running and testing the role with ostree managed nodes.

Reason: We have users who want to use the role to manage ostree
systems.

Result: Users can use the role to manage ostree managed nodes.
Signed-off-by: Rich Megginson <rmeggins@redhat.com>
