### PR TITLE
feat: sync with latest ansible-pcp

### DIFF
--- a/tests/check_pmie_webhook.yml
+++ b/tests/check_pmie_webhook.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Check if primary pmie is running
+  changed_when: false
+  shell: |
+    set -eu
+    if set -o | grep -q pipefail; then
+      set -o pipefail  # no pipefail on debian, some ubuntu
+    fi
+    pmprobe -I pmcd.pmie.pmcd_host | grep '"primary"'
+  when: (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
+         ansible_facts['distribution_major_version'] | int > 6) or
+         ansible_facts['distribution'] not in ['Fedora', 'RedHat', 'CentOS']
+
+# yamllint disable rule:line-length
+- name: Check if primary pmie uses webhook
+  changed_when: false
+  shell: |
+    set -eu
+    if set -o | grep -q pipefail; then
+      set -o pipefail  # no pipefail on debian, some ubuntu
+    fi
+    pmieconf -f /var/lib/pcp/config/pmie/config.default list global webhook_endpoint | grep '"example"'
+    pmieconf -f /var/lib/pcp/config/pmie/config.default list global webhook_action | grep '"yes"'
+  when: (ansible_distribution in ['RedHat', 'CentOS'] and
+         (ansible_facts['distribution_version'] is version('9.3', '<'))) or
+         ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+# yamllint enable rule:line-length

--- a/tests/tests_verify_mssql.yml
+++ b/tests/tests_verify_mssql.yml
@@ -19,28 +19,24 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
-    - name: Ensure correct package manager for ostree systems
-      vars:
-        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-        ostree_booted_file: /run/ostree-booted
-      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+    - name: Determine if system is ostree and set flag
+      when: not __ansible_pcp_is_ostree is defined
       block:
         - name: Check if system is ostree
           stat:
-            path: "{{ ostree_booted_file }}"
+            path: /run/ostree-booted
           register: __ostree_booted_stat
 
-        - name: Set package manager to use for ostree
-          ansible.utils.update_fact:
-            updates:
-              - path: ansible_facts.pkg_mgr
-                value: "{{ ostree_pkg_mgr }}"
-          when: __ostree_booted_stat.stat.exists
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
     - name: Ensure python3-pyodbc is installed
       package:
         name: python3-pyodbc
         state: present
+        use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
   tasks:
     - name: Check MSSQL functionality

--- a/tests/tests_verify_pmie_webhook.yml
+++ b/tests/tests_verify_pmie_webhook.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Test pmie webhook configuration
+  hosts: all
+
+  roles:
+    - role: performancecopilot.metrics.pcp
+      vars:
+        pcp_pmie_endpoint: https://example.com:12345/webhook
+
+  pre_tasks:
+    - name: Skip test if not supported by platform
+      meta: end_host
+      when: (ansible_distribution in ['RedHat', 'CentOS'] and
+             (ansible_facts['distribution_version'] is version('9.3', '<'))) or
+             ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+
+    - name: Save state of services
+      import_tasks: get_services_state.yml
+
+  tasks:
+    - name: Check if configuring pmie webhook works
+      include_tasks: check_pmie_webhook.yml
+
+  post_tasks:
+    - name: Restore state of services
+      import_tasks: restore_services_state.yml

--- a/tests/tests_verify_postfix.yml
+++ b/tests/tests_verify_postfix.yml
@@ -18,30 +18,26 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
-    - name: Ensure correct package manager for ostree systems
-      vars:
-        ostree_pkg_mgr: ansible.posix.rhel_rpm_ostree
-        ostree_booted_file: /run/ostree-booted
-      when: ansible_facts.pkg_mgr | d("") != ostree_pkg_mgr
+    - name: Determine if system is ostree and set flag
+      when: not __ansible_pcp_is_ostree is defined
       block:
         - name: Check if system is ostree
           stat:
-            path: "{{ ostree_booted_file }}"
+            path: /run/ostree-booted
           register: __ostree_booted_stat
 
-        - name: Set package manager to use for ostree
-          ansible.utils.update_fact:
-            updates:
-              - path: ansible_facts.pkg_mgr
-                value: "{{ ostree_pkg_mgr }}"
-          when: __ostree_booted_stat.stat.exists
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
-    - name: Ensure postfix is installed
+    - name: Ensure Postfix is installed
       package:
         name:
           - postfix
           - postfix-perl-scripts
         state: present
+        use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
     # needed for older versions of PCP which mandated a log file
     # exists in order that the PMDA would start up at all.

--- a/vendor/github.com/performancecopilot/ansible-pcp/docs/pcp/setup.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/docs/pcp/setup.yml
@@ -4,6 +4,7 @@
   roles:
     - role: performancecopilot.metrics.pcp
       vars:
+        pcp_pmie_endpoint: https://example.com/webhook
         pcp_pmlogger_interval: 10
         pcp_optional_agents: [dm, nfsclient, openmetrics]
         pcp_explicit_labels:

--- a/vendor/github.com/performancecopilot/ansible-pcp/galaxy.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/galaxy.yml
@@ -2,7 +2,7 @@
 ### REQUIRED
 namespace: performancecopilot
 name: metrics
-version: 2.2.9
+version: 2.3.0
 readme: README.md
 authors:
   - Jan Kurik <jkurik@redhat.com>
@@ -46,4 +46,5 @@ build_ignore:
   - tests
   - tox.ini
 
-dependencies: {}
+dependencies:
+  ansible.posix: '*'  # for rpm-ostree

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/bpftrace/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/bpftrace/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish bpftrace package names
   set_fact:
     __bpftrace_packages_extra: "{{ __bpftrace_packages +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __bpftrace_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __bpftrace_packages_extra | d([])
 
 - name: Extract allowed bpftrace user accounts

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/elasticsearch/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/elasticsearch/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Elasticsearch metrics package names
   set_fact:
     __elasticsearch_packages_extra: "{{ __elasticsearch_packages_extra +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __elasticsearch_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __elasticsearch_packages_extra | d([])
 
 - name: Ensure PCP Elasticsearch agent configuration directory exists
@@ -51,16 +65,9 @@
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_agent | d(false) | bool
 
-- name: Check if system is ostree
-  stat:
-    path: "{{ ostree_booted_file }}"
-  vars:
-    ostree_booted_file: /run/ostree-booted
-  register: __ostree_booted_stat
-
 - name: Ensure correct service path for ostree systems
   when:
-    - __ostree_booted_stat.stat.exists
+    - __ansible_pcp_is_ostree | d(false)
     - __elasticsearch_service_path != "/etc/systemd/system"
   set_fact:
     __elasticsearch_service_path: /etc/systemd/system

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/grafana/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/grafana/tasks/main.yml
@@ -12,10 +12,24 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Grafana packages
   package:
     name: "{{ __grafana_packages + __grafana_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Get package facts now that Grafana is installed
   package_facts:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/mssql/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/mssql/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish SQL Server metrics package names
   set_fact:
     __mssql_packages_extra: "{{ __mssql_packages_pcp }}"
@@ -21,6 +33,8 @@
   package:
     name: "{{ __mssql_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __mssql_packages_extra | d([])
 
 - name: Ensure PCP SQL Server agent configuration directory exists

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/README.md
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/README.md
@@ -28,6 +28,10 @@ Default location for [pmlogger(1)](http://man7.org/linux/man-pages/man1/pmlogger
 
 An optional list of remote hostnames for which metric recording and inference rules should be installed, to be monitored from the host running the playbook.  By default, all performance rules evaluating to true will be logged to the local system log (for both the local host and remote hosts in the target hosts list), and daily archives will be created below *pcp_archive_dir*/*hostname* locally, again for each host listed in the target hosts list.
 
+### pcp_pmie_endpoint: ''
+
+Send inference events to the given webhook endpoint (URL) from [pmie(1)](http://man7.org/linux/man-pages/man1/pmie.1.html) performance rules.  The default is to log these events into the local system log only.
+
 ### pcp_single_control: 0
 
 Specifies whether the pcp_target_hosts configuration file(s) for pmie and pmlogger are in control.d form (the default) or in the single file form where /*etc*/*pcp*/*pmlogger*/*control* and /*etc*/*pcp*/*pmie*/*control* are used to setup the target hosts list for monitoring.

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/defaults/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/defaults/main.yml
@@ -5,6 +5,7 @@ pcp_rest_api: false
 pcp_pmlogger_discard: 14
 pcp_pmlogger_interval: 60
 pcp_archive_dir: /var/log/pcp/pmlogger
+pcp_pmie_endpoint: ''
 pcp_pmcd_localonly: 0
 pcp_pmproxy_localonly: 0
 pcp_pmlogger_localonly: 1

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/main.yml
@@ -12,15 +12,31 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Performance Co-Pilot packages
   package:
     name: "{{ __pcp_packages + __pcp_packages_extra + pcp_optional_packages }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Install authentication packages
   package:
     name: "{{ __pcp_sasl_packages }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __pcp_sasl_packages | d([])
     - pcp_accounts | d({})

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmie.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmie.yml
@@ -31,6 +31,58 @@
   loop: "{{ __pcp_pmieconf_rules | default([]) }}"
   register: __pcp_register_changed_rules_for_hosts
 
+- name: Ensure performance rule actions are installed for targeted hosts
+  set_fact:
+    local_pmie: "default"
+
+- name: Check if global pmie webhook action is configured
+  lineinfile:
+    state: absent
+    path: "{{ __pcp_pmie_config_path }}/config.{{ item }}"
+    regexp: "//.*global webhook_action = yes"
+  check_mode: true
+  changed_when: false
+  register: __pcp_global_webhook_action_status
+  loop: "{{ pcp_target_hosts + [local_pmie] }}"
+  when:
+    - pcp_pmie_endpoint | length > 0
+
+- name: Configure global webhook action
+  # yamllint disable rule:line-length
+  command: "pmieconf -f {{ __pcp_pmie_config_path }}/config.{{ item.item }} modify global webhook_action yes"
+  loop: "{{ __pcp_global_webhook_action_status.results }}"
+  changed_when:
+    - pcp_pmie_endpoint | length > 0
+    - item.found == 0
+  when:
+    - pcp_pmie_endpoint | length > 0
+    - item.found == 0
+  register: __pcp_register_changed_actions_for_hosts
+  # yamllint enable rule:line-length
+
+- name: Check if global webhook endpoint is configured
+  lineinfile:
+    state: absent
+    path: "{{ __pcp_pmie_config_path }}/config.{{ item }}"
+    regexp: "//.*global webhook_endpoint = \"{{ pcp_pmie_endpoint }}\""
+  check_mode: true
+  changed_when: false
+  register: __pcp_global_webhook_endpoint_status
+  loop: "{{ pcp_target_hosts + [local_pmie] }}"
+
+- name: Configure global webhook endpoint
+  # yamllint disable rule:line-length
+  command: "pmieconf -f {{ __pcp_pmie_config_path }}/config.{{ item.item }} modify global webhook_endpoint {{ pcp_pmie_endpoint }}"
+  loop: "{{ __pcp_global_webhook_endpoint_status.results }}"
+  changed_when:
+    - pcp_pmie_endpoint | length > 0
+    - item.found == 0
+  when:
+    - pcp_pmie_endpoint | length > 0
+    - item.found == 0
+  register: __pcp_register_changed_actions_for_hosts
+  # yamllint enable rule:line-length
+
 - name: Ensure extra rules symlinks have been created for targeted hosts
   file:
     src: "{{ __pcp_pmieconf_path }}/{{ item }}"
@@ -67,6 +119,7 @@
       __pcp_register_changed_group_dir is changed or
       __pcp_register_changed_group_link_dir is changed or
       __pcp_register_changed_rules_for_hosts is changed or
+      __pcp_register_changed_actions_for_hosts is changed or
       __pcp_register_changed_symlinks_for_hosts is changed or
       __pcp_register_changed_target_hosts_controld is changed or
       __pcp_register_changed_target_hosts_single is changed }}"

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/vars/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/vars/main.yml
@@ -19,6 +19,7 @@ __pcp_pmlogger_control_path: /etc/pcp/pmlogger/control
 
 __pcp_pmie_control_d_path: /etc/pcp/pmie/control.d
 __pcp_pmie_control_path: /etc/pcp/pmie/control
+__pcp_pmie_config_path: /var/lib/pcp/config/pmie
 
 __pcp_pmieconf_path: /etc/pcp/pmieconf
 __pcp_pmieconf_link_path: /var/lib/pcp/config/pmieconf

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/postfix/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/postfix/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Postfix metrics package names
   set_fact:
     __postfix_packages_extra: "{{ __postfix_packages_pcp }}"
@@ -21,4 +33,6 @@
   package:
     name: "{{ __postfix_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __postfix_packages_extra | d([])

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/redis/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/redis/tasks/main.yml
@@ -12,10 +12,24 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Redis packages
   package:
     name: "{{ __redis_packages + __redis_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Ensure Redis configuration directory exists
   file:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/README.md
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/README.md
@@ -1,6 +1,6 @@
 # performancecopilot.metrics.repository
 
-Installs and configures the upstream package repositories - currently hosted at [jFrog Artifactory](https://performancecopilot.jfrog.io/ui/builds) - to get the very latest [Performance Co-Pilot](https://pcp.io/) toolkit releases.
+Installs and configures the upstream package repositories - currently hosted at [Packagecloud](https://packagecloud.io/performancecopilot/pcp) - to get the very latest [Performance Co-Pilot](https://pcp.io/) toolkit releases.
 
 ## Requirements
 

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/artifactory.debs.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/artifactory.debs.j2
@@ -1,1 +1,0 @@
-deb https://performancecopilot.jfrog.io/artifactory/pcp-deb-release {{ __repository_distro_name }} main

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/artifactory.rpms.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/artifactory.rpms.j2
@@ -1,9 +1,0 @@
-{{ ansible_managed | comment }}
-{{ "performancecopilot:ansible-pcp" | comment(prefix="", postfix="") }}
-[performancecpilot]
-name=Performance Co-Pilot
-baseurl=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ __repository_distro_name }}/$releasever/$basearch
-enabled=1
-gpgcheck=0
-gpgkey=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ __repository_distro_name }}/$releasever/$basearch/repodata/repomd.xml.key
-repo_gpgcheck=1

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/packagecloud.debs.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/packagecloud.debs.j2
@@ -1,0 +1,2 @@
+deb https://packagecloud.io/performancecopilot/pcp/{{ __repository_distro_name }} {{ ansible_distribution_release }} main
+deb-src https://packagecloud.io/performancecopilot/pcp/{{ __repository_distro_name }} {{ ansible_distribution_release }} main

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/packagecloud.rpms.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/templates/packagecloud.rpms.j2
@@ -1,0 +1,23 @@
+{{ ansible_managed | comment }}
+{{ "performancecopilot:ansible-pcp" | comment(prefix="", postfix="") }}
+[performancecopilot]
+name=Performance Co-Pilot
+baseurl=https://packagecloud.io/performancecopilot/pcp/{{ __repository_distro_name }}/$releasever/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgcheck=0
+gpgkey=https://packagecloud.io/performancecopilot/pcp/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+
+[performancecopilot-source]
+name=Performance Co-Pilot source
+baseurl=https://packagecloud.io/performancecopilot/pcp/{{ __repository_distro_name }}/$releasever/SRPMS
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/performancecopilot/pcp/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/vars/Debian.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/vars/Debian.yml
@@ -2,4 +2,4 @@
 ---
 # Put internal variables here with Debian specific values.
 
-__repository_distro_name: "{{ ansible_facts['distribution_release'] }}"
+__repository_distro_name: "{{ ansible_distribution | lower }}"

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/vars/RedHat.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/repository/vars/RedHat.yml
@@ -2,4 +2,4 @@
 ---
 # Put internal variables here with Red Hat specific values.
 
-__repository_distro_name: "centos"
+__repository_distro_name: "el"

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/spark/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/spark/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Spark metrics package names
   set_fact:
     __spark_packages_extra: "{{ __spark_packages_extra +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __spark_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __spark_packages_extra | d([])
 
 - name: Ensure PCP OpenMetrics agent is configured for Spark
@@ -52,16 +66,9 @@
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
 
-- name: Check if system is ostree
-  stat:
-    path: "{{ ostree_booted_file }}"
-  vars:
-    ostree_booted_file: /run/ostree-booted
-  register: __ostree_booted_stat
-
 - name: Ensure correct service path for ostree systems
   when:
-    - __ostree_booted_stat.stat.exists
+    - __ansible_pcp_is_ostree | d(false)
     - __spark_service_path != "/etc/systemd/system"
   set_fact:
     __spark_service_path: /etc/systemd/system


### PR DESCRIPTION
6cbb8cc Bump version to 2.3.0 for latest changes
35389e7 feat: support for ostree systems
630e87e fix: add missing pmie webhook action configuration functionality
e50979a fix: switch the repository role over to using Packagecloud

git-subtree-dir: vendor/github.com/performancecopilot/ansible-pcp
git-subtree-split: 6cbb8cc0accebed05985390e677ac1a760294803
