### PR TITLE
test: stop firewall if used by test

### DIFF
--- a/tests/restore_services_state.yml
+++ b/tests/restore_services_state.yml
@@ -25,3 +25,9 @@
     - redis
     - grafana-server
 # yamllint enable rule:line-length
+
+- name: Stop firewall
+  service:
+    name: firewalld
+    state: stopped
+  when: metrics_manage_firewall | bool


### PR DESCRIPTION
If the test enabled the firewall, stop it during cleanup.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
