### PR TITLE
fix: add support for Valkey

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -29,7 +29,7 @@ mock_roles:
   - performancecopilot.metrics.mssql
   - performancecopilot.metrics.pcp
   - performancecopilot.metrics.postfix
-  - performancecopilot.metrics.redis
+  - performancecopilot.metrics.keyserver
   - performancecopilot.metrics.repository
   - performancecopilot.metrics.spark
 supported_ansible_also:

--- a/.ostree/packages-runtime-CentOS-10.txt
+++ b/.ostree/packages-runtime-CentOS-10.txt
@@ -5,5 +5,4 @@ pcp-export-pcp2elasticsearch
 pcp-pmda-bpftrace
 pcp-pmda-mssql
 pcp-system-tools
-redis
-redis-doc
+valkey

--- a/.ostree/packages-runtime-RedHat-10.txt
+++ b/.ostree/packages-runtime-RedHat-10.txt
@@ -5,5 +5,4 @@ pcp-export-pcp2elasticsearch
 pcp-pmda-bpftrace
 pcp-pmda-mssql
 pcp-system-tools
-redis
-redis-doc
+valkey

--- a/.ostree/packages-testing-CentOS-10.txt
+++ b/.ostree/packages-testing-CentOS-10.txt
@@ -12,5 +12,4 @@ pcp-zeroconf
 postfix
 postfix-perl-scripts
 python3-pyodbc
-redis
-redis-doc
+valkey

--- a/.ostree/packages-testing-Fedora.txt
+++ b/.ostree/packages-testing-Fedora.txt
@@ -12,6 +12,4 @@ pcp-zeroconf
 postfix
 postfix-perl-scripts
 python3-pyodbc
-redis
-redis-doc
-RediSearch
+valkey

--- a/.ostree/packages-testing-RedHat-10.txt
+++ b/.ostree/packages-testing-RedHat-10.txt
@@ -12,5 +12,4 @@ pcp-zeroconf
 postfix
 postfix-perl-scripts
 python3-pyodbc
-redis
-redis-doc
+valkey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,13 +192,13 @@ Changelog
 - Use the firewall role and the selinux role from the metrics role
 
 - Introduce metrics_manage_firewall to use the firewall role to
-  manage the pmcd port, the pmproxy ports, the grafana port and
-  the redis port depending upon the configuration parameters.
+  manage the pmcd, pmproxy, grafana and valkey or redis ports,
+  depending on the configuration parameters.
   metrics_manage_firewall is set to false, by default.
 
 - Introduce metrics_manage_selinux to use the selinux role to
-  manage the pmcd port, the pmproxy ports, the grafana port and
-  the redis port depending upon the configuration parameters.
+  manage the pmcd, pmproxy, grafana and valkey or redis ports,
+  depending on the configuration parameters.
   metrics_manage_selinux is set to false, by default.
 
 - Add the test check task check_firewall_selinux.yml for verify

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ from the standard repositories on Fedora, CentOS 8, and RHEL 8.  On RHEL
 on the managed host.
 
 The role can optionally use Grafana v6+ (`metrics_graph_service`) and
-Redis v5+ (`metrics_query_service`) on Fedora, CentOS 8, RHEL 8 and later.
+Valkey (`metrics_query_service`) on Fedora, CentOS 10, RHEL 10 and later,
+or Redis v5+ (`metrics_query_service`) on CentOS 8 or 9, RHEL 8 or 9.
 
 ### Collection requirements
 
@@ -70,9 +71,11 @@ RHEL 8, or later versions of these platforms.
 ### metrics_query_service: false
 
 Boolean flag allowing host to be setup with time series query services.
-Enabling this starts PCP and Redis servers for querying recorded PCP metrics.
-This option requires Redis v5+ which is available on Fedora, CentOS 8,
-RHEL 8, or later versions of these platforms.
+Enabling this starts PCP and Valkey or Redis servers for querying any
+recorded PCP metrics.
+This option requires either Valkey or Redis v5+ which is available on
+Fedora, CentOS 8, RHEL 8, or later versions of these platforms (Valkey
+is the prefered solution on Fedora, Centos 10, RHEL 10 and later).
 
 ### metrics_into_elasticsearch: false
 
@@ -115,14 +118,14 @@ The metrics collector to use to provide metrics.
 Currently Performance Co-Pilot is the only supported metrics provider.
 When using the PCP provider these TCP ports will be used - 44321 (pmcd,
 live metric value sampling), 44322 (pmproxy, with metrics_query_service
-or metrics_graph_service), 6379 (redis-server for metrics_query_service)
-and 3000 (grafana-server for metrics_graph_service).
+or metrics_graph_service), 6379 (either valkey-server or redis-server for
+metrics_query_service) and 3000 (grafana-server for metrics_graph_service).
 
 ### metrics_manage_firewall: false
 
 Boolean flag allowing to configure firewall using the firewall role.
-Manage the pmcd port, the pmproxy port, the Grafana port and the Redis
-port depending upon the configuration parameters.
+Manage the pmcd port, the pmproxy port, the Grafana port and either the
+Valkey or Redis port depending upon the configuration parameters.
 If the variable is set to false, the `metrics role` does not manage the
 firewall.
 
@@ -136,16 +139,17 @@ NOTE: the firewall management is not supported on RHEL 6.
 ### metrics_manage_selinux: false
 
 Boolean flag allowing to configure selinux using the selinux role.
-Assign the pmcd port, the pmproxy port, the Grafana port and the Redis
-port depending upon the configuration parameters.
+Assign the pmcd port, the pmproxy port, the Grafana port and either the
+Valkey or Redis port depending upon the configuration parameters.
 If the variable is set to false, the `metrics role` does not manage the
 selinux.
 
 Please note that the pmcd and pmproxy services are in the "ephemeral"
 range requiring no special setup and the Grafana port is "unregistered".
-The Redis port is gated by the redis_port_t SELinux type and may need to
-be further configured, if you require direct access (not required if you
-are accessing it from metrics role tools like Grafana and PCP).
+The Valkey or Redis ports are gated by the valkey_port_t or redis_port_t
+SELinux types respectively, and may need to be further configured if you
+require direct access (not required if you are accessing it from metrics
+role tools like Grafana and PCP).
 Use the `selinux` system role to manage port access, for SELinux contexts.
 
 NOTE: `metrics_manage_selinux` is limited to *adding* policy.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ metrics_retention_days: 7
 # analysis) and automated rule inference (for alerting).
 metrics_monitored_hosts: []
 
-# Provide a scalable query language (using Redis) and the
+# Provide a scalable query language (using Valkey) and the
 # PMWEBAPI(3) REST API for metrics at localhost:44322
 # OpenMetrics endpoint at localhost:44322/metrics
 metrics_query_service: false
@@ -39,8 +39,8 @@ metrics_password: metrics
 metrics_provider: pcp
 
 # If true, manage the pmcd port, pmproxy ports, grafana service and
-# redis service using the firewall role depending upon the configuration
-# parameters.
+# valkey or redis service using the firewall role depending upon the
+# configuration parameters.
 metrics_manage_firewall: false
 
 # If true, manage the pmcd port, pmproxy ports using the selinux role

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -35,5 +35,6 @@ galaxy_info:
     - redis
     - telemetry
     - timeseries
+    - valkey
     - visualization
 dependencies: []

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -33,7 +33,7 @@
     - name: Service for valkey
       set_fact:
         __metrics_firewall: "{{ __metrics_firewall |
-            union([{'service': 'valkey', 'state': 'enabled'}]) }}"
+            union([{'ports': 6379, 'state': 'enabled'}]) }}"
       when:
         - metrics_query_service | bool
         - ansible_facts['distribution_version'] is version('10', '>=')

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -21,7 +21,7 @@
         __metrics_firewall: "{{ __metrics_firewall |
             union([{'port': '44322/tcp', 'state': 'enabled'}]) }}"
       when:
-        - metrics_graph_service|bool or metrics_query_service|bool
+        - metrics_graph_service | bool or metrics_query_service | bool
 
     - name: Service for grafana
       set_fact:
@@ -30,12 +30,21 @@
       when:
         - metrics_graph_service|bool
 
+    - name: Service for valkey
+      set_fact:
+        __metrics_firewall: "{{ __metrics_firewall |
+            union([{'service': 'valkey', 'state': 'enabled'}]) }}"
+      when:
+        - metrics_query_service | bool
+        - ansible_facts['distribution_version'] is version('10', '>=')
+
     - name: Service for redis
       set_fact:
         __metrics_firewall: "{{ __metrics_firewall |
             union([{'service': 'redis', 'state': 'enabled'}]) }}"
       when:
-        - metrics_query_service|bool
+        - metrics_query_service | bool
+        - ansible_facts['distribution_version'] is version('10', '<')
 
     - name: Ensure the service and the port status with the firewall role
       include_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,11 +75,9 @@
   when: metrics_from_bpftrace | d(false) | bool
 
 - name: Setup metric querying service.
-  vars:
-    redis_metrics_provider: "{{ metrics_provider }}"
   include_role:
     # noqa role-name[path]
-    name: "{{ role_path }}/roles/redis"
+    name: "{{ role_path }}/roles/keyserver"
   when: metrics_query_service | bool
 
 - name: Setup metric collection service.

--- a/tests/check_default_datasources.yml
+++ b/tests/check_default_datasources.yml
@@ -14,4 +14,26 @@
     - Redis
     - Vector
     - bpftrace
+  when:
+    - ansible_distribution in ['RedHat', 'CentOS']
+    - ansible_distribution_major_version | int > 6
+    - ansible_distribution_major_version | int < 10
+
+- name: Check if grafana-pcp datasources are configured
+  uri:
+    url: "http://admin:admin@localhost:3000/api/datasources/name/PCP%20{{ item }}"
+    force_basic_auth: true
+    headers:
+      Content-Type: application/json
+      Accept: application/json
+    method: GET
+    status_code: 200
+  loop:
+    - Valkey
+    - Vector
+    - bpftrace
+  when: (ansible_distribution in ['RedHat', 'CentOS'] and
+         ansible_distribution_major_version | int >= 10) or
+         ansible_distribution not in ['RedHat', 'CentOS']
+
 # yamllint enable rule:line-length

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -18,6 +18,18 @@
       when:
         - metrics_graph_service|d(false)|bool
 
+    - name: "Check firewall service status for valkey;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-services
+      register: _result
+      failed_when: "'valkey' not in _result.stdout"
+      changed_when: false
+      when:
+        - metrics_query_service | d(false) | bool
+        - ansible_distribution not in ['RedHat', 'CentOS'] or
+          (ansible_distribution in ['RedHat', 'CentOS'] and
+          ansible_distribution_major_version | int >= 10)
+
     - name: "Check firewall service status for redis;
              metrics_manage_firewall is true"
       command: firewall-cmd --list-services
@@ -26,6 +38,9 @@
       changed_when: false
       when:
         - metrics_query_service|d(false)|bool
+        - ansible_distribution in ['RedHat', 'CentOS']
+        - ansible_distribution_major_version | int > 6
+        - ansible_distribution_major_version | int < 10
 
     - name: "Check firewall port status for pmproxy;
              metrics_manage_firewall is true"

--- a/tests/check_keyserver.yml
+++ b/tests/check_keyserver.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Check if Valkey responds
+  shell: |
+    set -euo pipefail
+    valkey-cli PING | grep PONG
+  changed_when: false
+  when: (ansible_distribution in ['RedHat', 'CentOS'] and
+         ansible_distribution_major_version | int >= 10) or
+         ansible_distribution not in ['RedHat', 'CentOS']
+
+- name: Check if Redis responds
+  shell: |
+    set -euo pipefail
+    redis-cli PING | grep PONG
+  changed_when: false
+  when:
+    - ansible_distribution in ['RedHat', 'CentOS']
+    - ansible_distribution_major_version | int > 6
+    - ansible_distribution_major_version | int < 10

--- a/tests/check_redis.yml
+++ b/tests/check_redis.yml
@@ -1,7 +1,0 @@
-# SPDX-License-Identifier: MIT
----
-- name: Check if Redis responds
-  shell: |
-    set -euo pipefail
-    redis-cli PING | grep PONG
-  changed_when: false

--- a/tests/restore_services_state.yml
+++ b/tests/restore_services_state.yml
@@ -23,6 +23,7 @@
     - pmie
     - pmproxy
     - redis
+    - valkey
     - grafana-server
 # yamllint enable rule:line-length
 

--- a/tests/roles/keyserver
+++ b/tests/roles/keyserver
@@ -1,0 +1,1 @@
+../../vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver

--- a/tests/roles/redis
+++ b/tests/roles/redis
@@ -1,1 +1,0 @@
-../../vendor/github.com/performancecopilot/ansible-pcp/roles/redis

--- a/tests/tests_verify_fullstack.yml
+++ b/tests/tests_verify_fullstack.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Test the full PCP/Redis/Grafana stack
+- name: Test the full PCP and Grafana stack
   hosts: all
   vars:
     metrics_query_service: true
@@ -32,7 +32,7 @@
             - check_pcp.yml
             - check_pmlogger.yml
             - check_pmie.yml
-            - check_redis.yml
+            - check_keyserver.yml
             - check_pmproxy.yml
             - check_grafana.yml
             - check_grafanapcp.yml

--- a/tests/tests_verify_query.yml
+++ b/tests/tests_verify_query.yml
@@ -29,7 +29,7 @@
             - check_pcp.yml
             - check_pmlogger.yml
             - check_pmie.yml
-            - check_redis.yml
+            - check_keyserver.yml
             - check_pmproxy.yml
             - check_firewall_selinux.yml
 

--- a/vendor/github.com/performancecopilot/ansible-pcp/.github/workflows/pr-title-lint.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/.github/workflows/pr-title-lint.yml
@@ -1,3 +1,4 @@
+---
 name: PR Title Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/redis_5.conf.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/redis_5.conf.j2
@@ -215,7 +215,7 @@ always-show-logo yes
 #
 #   save ""
 
-{% if redis_save_to_disk %}
+{% if keyserver_save_to_disk %}
 save 900 1
 save 300 10
 save 60 10000

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/redis_6.conf.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/redis_6.conf.j2
@@ -285,7 +285,7 @@ always-show-logo yes
 #
 #   save ""
 
-{% if redis_save_to_disk %}
+{% if keyserver_save_to_disk %}
 save 900 1
 save 300 10
 save 60 10000

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/valkey_7.conf.j2
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/keyserver/templates/valkey_7.conf.j2
@@ -333,7 +333,7 @@ daemonize no
 #
 # When the server runs non daemonized, no pid file is created if none is
 # specified in the configuration. When the server is daemonized, the pid file
-# is used even if not specified, defaulting to "/var/run/redis.pid".
+# is used even if not specified, defaulting to "/var/run/valkey.pid".
 #
 # Creating a pid file is best effort: if the server is not able to create it
 # nothing bad happens, the server will start and run normally.
@@ -361,7 +361,7 @@ logfile /var/log/valkey/valkey.log
 # syslog-enabled no
 
 # Specify the syslog identity.
-# syslog-ident redis
+# syslog-ident valkey
 
 # Specify the syslog facility. Must be USER or between LOCAL0-LOCAL7.
 # syslog-facility local0
@@ -439,6 +439,12 @@ locale-collate ""
 # You can set these explicitly by uncommenting the following line.
 #
 # save 3600 1 300 100 60 10000
+
+{% if keyserver_save_to_disk %}
+save 900 1 300 10 60 10000
+{% else %}
+save ""
+{% endif %}
 
 # By default the server will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
@@ -2269,7 +2275,7 @@ jemalloc-bg-thread yes
 # the bgsave child process. The syntax to specify the cpu list is the same as
 # the taskset command:
 #
-# Set redis server/io threads to cpu affinity 0,2,4,6:
+# Set valkey server/io threads to cpu affinity 0,2,4,6:
 # server_cpulist 0-7:2
 #
 # Set bio threads to cpu affinity 1,3:


### PR DESCRIPTION
Enhancement: Support Valkey as an alternative to Redis

Reason: Redis is no longer open source and is being removed from distributions

Result: PCP scalable query language + Grafana support continue to function

Issue Tracker Tickets (Jira or BZ if any): RHEL-29939