### PR TITLE
fix: add leading triple-hyphen to all github workflow files

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,3 +1,4 @@
+---
 name: PR Title Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -1,3 +1,4 @@
+---
 # yamllint disable rule:line-length
 name: Sync ansible-pcp git subtree
 on:  # yamllint disable-line rule:truthy

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,3 +1,4 @@
+---
 # yamllint disable rule:line-length
 name: Woke
 on:  # yamllint disable-line rule:truthy


### PR DESCRIPTION
Seems to resolve a github actions lint-style warning.