### PR TITLE
fix: Use correct syntax for keyserver port and test check

### DIFF
--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -33,7 +33,7 @@
     - name: Service for valkey
       set_fact:
         __metrics_firewall: "{{ __metrics_firewall |
-            union([{'ports': 6379, 'state': 'enabled'}]) }}"
+            union([{'port': '6379/tcp', 'state': 'enabled'}]) }}"
       when:
         - metrics_query_service | bool
         - ansible_facts['distribution_version'] is version('10', '>=')

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -18,17 +18,19 @@
       when:
         - metrics_graph_service|d(false)|bool
 
-    - name: "Check firewall service status for valkey;
-             metrics_manage_firewall is true"
-      command: firewall-cmd --list-services
-      register: _result
-      failed_when: "'valkey' not in _result.stdout"
-      changed_when: false
-      when:
-        - metrics_query_service | d(false) | bool
-        - ansible_distribution not in ['RedHat', 'CentOS'] or
-          (ansible_distribution in ['RedHat', 'CentOS'] and
-          ansible_distribution_major_version | int >= 10)
+    # NOTE: not all versions of firewall have a "valkey" service yet
+    # so for now, we are using the port - see below
+    # - name: "Check firewall service status for valkey;
+    #          metrics_manage_firewall is true"
+    #   command: firewall-cmd --list-services
+    #   register: _result
+    #   failed_when: "'valkey' not in _result.stdout"
+    #   changed_when: false
+    #   when:
+    #     - metrics_query_service | d(false) | bool
+    #     - ansible_distribution not in ['RedHat', 'CentOS'] or
+    #       (ansible_distribution in ['RedHat', 'CentOS'] and
+    #       ansible_distribution_major_version | int >= 10)
 
     - name: "Check firewall service status for redis;
              metrics_manage_firewall is true"
@@ -59,6 +61,18 @@
       register: _result
       failed_when: "'44321/tcp' not in _result.stdout"
       changed_when: false
+
+    - name: "Check firewall port status for valkey;
+             metrics_manage_firewall is true"
+      command: firewall-cmd --list-ports
+      register: _result
+      failed_when: "'6379/tcp' not in _result.stdout"
+      changed_when: false
+      when:
+        - metrics_query_service | d(false) | bool
+        - ansible_distribution not in ['RedHat', 'CentOS'] or
+          (ansible_distribution in ['RedHat', 'CentOS'] and
+          ansible_distribution_major_version | int >= 10)
 
 - name: Check associated selinux ports (metrics_manage_selinux is true)
   shell: |-


### PR DESCRIPTION
Cause: The role was using incorrect syntax for specifying the
keyserver port for the firewall.

Consequence: The role would give an error when configuring
the keyserver port in the firewall.

Fix: Use the correct syntax in the role and in the test
used to check the firewall.

Result: The role can configure the firewall port for the
keyserver correctly.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
