### PR TITLE
test https://github.com/performancecopilot/ansible-pcp/pull/82

### DIFF
--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/bpftrace/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/bpftrace/tasks/main.yml
@@ -30,7 +30,7 @@
                                 __bpftrace_packages_extra }}"
   when:
     - bpftrace_metrics_provider == 'pcp'
-    - __bpftrace_packages_pcp | d([])
+    - __bpftrace_packages_pcp | d([]) | length > 0
 
 - name: Establish bpftrace metrics package names
   set_fact:
@@ -38,7 +38,7 @@
                                 __bpftrace_packages_extra }}"
   when:
     - bpftrace_metrics_provider == 'pcp'
-    - __bpftrace_packages_pcp | d([])
+    - __bpftrace_packages_pcp | d([]) | length > 0
 
 - name: Install needed bpftrace metrics packages
   package:
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __bpftrace_packages_extra | d([])
+  when: __bpftrace_packages_extra | d([]) | length > 0
 
 - name: Extract allowed bpftrace user accounts
   set_fact:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/elasticsearch/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/elasticsearch/tasks/main.yml
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __elasticsearch_packages_extra | d([])
+  when: __elasticsearch_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP Elasticsearch agent configuration directory exists
   file:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/mssql/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/mssql/tasks/main.yml
@@ -35,7 +35,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __mssql_packages_extra | d([])
+  when: __mssql_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP SQL Server agent configuration directory exists
   file:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/main.yml
@@ -38,8 +38,8 @@
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
-    - __pcp_sasl_packages | d([])
-    - pcp_accounts | d({})
+    - __pcp_sasl_packages | d([]) | length > 0
+    - pcp_accounts | d([]) | length > 0
 
 - name: Include pmcd
   include_tasks: pmcd.yml

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmcd.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmcd.yml
@@ -89,7 +89,7 @@
     dest: "{{ __pcp_pmcd_saslconf_path }}"
     mode: "0644"
   register: __pcp_register_changed_authentication
-  when: pcp_accounts | d([])
+  when: pcp_accounts | d([]) | length > 0
 
 - name: Set variable to do pmcd restart if needed
   set_fact:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmie.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmie.yml
@@ -101,7 +101,7 @@
   register: __pcp_register_changed_target_hosts_controld
   when:
     - not pcp_single_control | d(false) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Enable performance metric inference for targeted hosts (single control)
   template:
@@ -111,7 +111,7 @@
   register: __pcp_register_changed_target_hosts_single
   when:
     - pcp_single_control | d(true) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Set variable to do pmie restart if needed
   set_fact:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmlogger.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/pcp/tasks/pmlogger.yml
@@ -34,7 +34,7 @@
   notify: Restart pmlogger
   when:
     - not pcp_single_control | d(false) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Enable performance metric logging for targeted hosts (single control)
   template:
@@ -44,7 +44,7 @@
   register: __pcp_register_changed_targeted_hosts_single
   when:
     - pcp_single_control | d(true) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Set variable to do pmlogger restart if needed
   set_fact:

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/postfix/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/postfix/tasks/main.yml
@@ -35,4 +35,4 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __postfix_packages_extra | d([])
+  when: __postfix_packages_extra | d([]) | length > 0

--- a/vendor/github.com/performancecopilot/ansible-pcp/roles/spark/tasks/main.yml
+++ b/vendor/github.com/performancecopilot/ansible-pcp/roles/spark/tasks/main.yml
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __spark_packages_extra | d([])
+  when: __spark_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP OpenMetrics agent is configured for Spark
   template:


### PR DESCRIPTION
Pull in the changes from https://github.com/performancecopilot/ansible-pcp/pull/82 to verify/prove that they work with Ansible 2.19 now. My run against my fork now passed everything except tests_verify_from_spark.yml , which fails the service due to an SELinux rejection. That is unrelated to Ansible 2.19.

:warning:  Don't merge this! It should land upstream first, and get pulled in via the weekly sub-tree sync.