### PR TITLE
feat: Support this role in container builds

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
         - "9"
   galaxy_tags:
     - analysis
+    - containerbuild
     - el6
     - el7
     - el8

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,26 @@
   when: __metrics_required_facts |
     difference(ansible_facts.keys() | list) | length > 0
 
+- name: Determine if system is booted with systemd
+  when: __metrics_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        # see https://www.man7.org/linux/man-pages/man1/systemctl.1.html#:~:text=is-system-running%20output
+        __metrics_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Add Elasticsearch to metrics domain list
   set_fact:
     __metrics_domains: "{{ __metrics_domains + ['elasticsearch'] }}"

--- a/tests/check_bpftrace.yml
+++ b/tests/check_bpftrace.yml
@@ -7,6 +7,7 @@
   retries: 10
   delay: 1
   changed_when: false
+  when: __metrics_is_booted | bool
 
 - name: Check if allowed users of bpftrace are configured
   shell: >-

--- a/tests/check_default_datasources.yml
+++ b/tests/check_default_datasources.yml
@@ -15,6 +15,7 @@
     - Vector
     - bpftrace
   when:
+    - __metrics_is_booted | bool
     - ansible_distribution in ['RedHat', 'CentOS']
     - ansible_distribution_major_version | int > 6
     - ansible_distribution_major_version | int < 10
@@ -32,8 +33,10 @@
     - Valkey
     - Vector
     - bpftrace
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and
-         ansible_distribution_major_version | int >= 10) or
-         ansible_distribution not in ['RedHat', 'CentOS']
+  when:
+    - __metrics_is_booted | bool
+    - (ansible_distribution in ['RedHat', 'CentOS'] and
+       ansible_distribution_major_version | int >= 10) or
+       ansible_distribution not in ['RedHat', 'CentOS']
 
 # yamllint enable rule:line-length

--- a/tests/check_firewall_selinux.yml
+++ b/tests/check_firewall_selinux.yml
@@ -10,7 +10,7 @@
   block:
     - name: "Check firewall service status for grafana;
              metrics_manage_firewall is true"
-      command: firewall-cmd --list-services
+      command: firewall-offline-cmd --list-services
       register: _result
       failed_when:
         - "'grafana' not in _result.stdout"
@@ -22,7 +22,7 @@
     # so for now, we are using the port - see below
     # - name: "Check firewall service status for valkey;
     #          metrics_manage_firewall is true"
-    #   command: firewall-cmd --list-services
+    #   command: firewall-offline-cmd --list-services
     #   register: _result
     #   failed_when: "'valkey' not in _result.stdout"
     #   changed_when: false
@@ -34,7 +34,7 @@
 
     - name: "Check firewall service status for redis;
              metrics_manage_firewall is true"
-      command: firewall-cmd --list-services
+      command: firewall-offline-cmd --list-services
       register: _result
       failed_when: "'redis' not in _result.stdout"
       changed_when: false
@@ -46,7 +46,7 @@
 
     - name: "Check firewall port status for pmproxy;
              metrics_manage_firewall is true"
-      command: firewall-cmd --list-ports
+      command: firewall-offline-cmd --list-ports
       register: _result
       failed_when:
         - "'44322/tcp' not in _result.stdout"
@@ -57,14 +57,14 @@
 
     - name: "Check firewall port status for pmcd;
              metrics_manage_firewall is true"
-      command: firewall-cmd --list-ports
+      command: firewall-offline-cmd --list-ports
       register: _result
       failed_when: "'44321/tcp' not in _result.stdout"
       changed_when: false
 
     - name: "Check firewall port status for valkey;
              metrics_manage_firewall is true"
-      command: firewall-cmd --list-ports
+      command: firewall-offline-cmd --list-ports
       register: _result
       failed_when: "'6379/tcp' not in _result.stdout"
       changed_when: false

--- a/tests/check_from_elasticsearch.yml
+++ b/tests/check_from_elasticsearch.yml
@@ -7,6 +7,7 @@
   retries: 10
   delay: 1
   changed_when: false
+  when: __metrics_is_booted | bool
 
 # yamllint disable rule:line-length
 - name: Set platform/version specific variables

--- a/tests/check_from_spark.yml
+++ b/tests/check_from_spark.yml
@@ -7,4 +7,6 @@
   retries: 10
   delay: 1
   changed_when: false
-  when: "'pcp-pmda-openmetrics' in __spark_packages_pcp"
+  when:
+    - "'pcp-pmda-openmetrics' in __spark_packages_pcp"
+    - __metrics_is_booted | bool

--- a/tests/check_fullstack_pmdas.yml
+++ b/tests/check_fullstack_pmdas.yml
@@ -13,3 +13,4 @@
   changed_when: false
   loop:
     - bpftrace
+  when: __metrics_is_booted | bool

--- a/tests/check_grafana.yml
+++ b/tests/check_grafana.yml
@@ -5,3 +5,4 @@
     url: http://localhost:3000/login
     method: GET
     status_code: 200
+  when: __metrics_is_booted | bool

--- a/tests/check_keyserver.yml
+++ b/tests/check_keyserver.yml
@@ -5,9 +5,11 @@
     set -euo pipefail
     valkey-cli PING | grep PONG
   changed_when: false
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and
-         ansible_distribution_major_version | int >= 10) or
-         ansible_distribution not in ['RedHat', 'CentOS']
+  when:
+    - (ansible_distribution in ['RedHat', 'CentOS'] and
+       ansible_distribution_major_version | int >= 10) or
+       ansible_distribution not in ['RedHat', 'CentOS']
+    - __metrics_is_booted | bool
 
 - name: Check if Redis responds
   shell: |
@@ -18,3 +20,4 @@
     - ansible_distribution in ['RedHat', 'CentOS']
     - ansible_distribution_major_version | int > 6
     - ansible_distribution_major_version | int < 10
+    - __metrics_is_booted | bool

--- a/tests/check_mssql.yml
+++ b/tests/check_mssql.yml
@@ -7,6 +7,7 @@
   retries: 10
   delay: 1
   changed_when: false
+  when: __metrics_is_booted | bool
 
 # yamllint disable rule:line-length
 - name: Set platform/version specific variables

--- a/tests/check_pcp.yml
+++ b/tests/check_pcp.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Check if PCP works
-  command: pcp
+  command: "{{ 'pcp' if __metrics_is_booted else 'pcp --version' }}"
   changed_when: false

--- a/tests/check_pmie.yml
+++ b/tests/check_pmie.yml
@@ -5,6 +5,8 @@
     set -euo pipefail
     pmprobe -I pmcd.pmie.pmcd_host | grep '"primary"'
   changed_when: false
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and
-         ansible_distribution_major_version | int > 6) or
-         ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+  when:
+    - (ansible_distribution in ['RedHat', 'CentOS'] and
+       ansible_distribution_major_version | int > 6) or
+       ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+    - __metrics_is_booted | bool

--- a/tests/check_pmie_webhook.yml
+++ b/tests/check_pmie_webhook.yml
@@ -8,9 +8,11 @@
       set -o pipefail  # no pipefail on debian, some ubuntu
     fi
     pmprobe -I pmcd.pmie.pmcd_host | grep '"primary"'
-  when: (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
-         ansible_facts['distribution_major_version'] | int > 6) or
-         ansible_facts['distribution'] not in ['Fedora', 'RedHat', 'CentOS']
+  when:
+    - (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
+       ansible_facts['distribution_major_version'] | int > 6) or
+       ansible_facts['distribution'] not in ['Fedora', 'RedHat', 'CentOS']
+    - __metrics_is_booted | bool
 
 # yamllint disable rule:line-length
 - name: Check if primary pmie uses webhook
@@ -22,7 +24,10 @@
     fi
     pmieconf -f /var/lib/pcp/config/pmie/config.default list global webhook_endpoint | grep '"example"'
     pmieconf -f /var/lib/pcp/config/pmie/config.default list global webhook_action | grep '"yes"'
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and
-         (ansible_facts['distribution_version'] is version('9.3', '<'))) or
-         ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+  when:
+    - (ansible_distribution in ['RedHat', 'CentOS'] and
+       (ansible_facts['distribution_version'] is version('9.3', '<'))) or
+       ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+    - __metrics_is_booted | bool
+
 # yamllint enable rule:line-length

--- a/tests/check_pmlogger.yml
+++ b/tests/check_pmlogger.yml
@@ -5,9 +5,11 @@
     set -euo pipefail
     pmprobe -I pmcd.pmlogger.pmcd_host | grep '"primary"'
   changed_when: false
-  when: (ansible_distribution in ['RedHat', 'CentOS'] and
-         ansible_distribution_major_version | int > 6) or
-         ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+  when:
+    - (ansible_distribution in ['RedHat', 'CentOS'] and
+       ansible_distribution_major_version | int > 6) or
+       ansible_distribution not in ['Fedora', 'RedHat', 'CentOS']
+    - __metrics_is_booted | bool
 
 - name: Check the ansible_managed header in the configuration file
   vars:

--- a/tests/check_pmproxy.yml
+++ b/tests/check_pmproxy.yml
@@ -5,6 +5,7 @@
     url: http://localhost:44322/series/ping
     method: GET
     status_code: 200
+  when: __metrics_is_booted | bool
 
 - name: Check the ansible_managed header in the configuration file
   vars:

--- a/tests/check_postfix.yml
+++ b/tests/check_postfix.yml
@@ -7,3 +7,4 @@
   retries: 10
   delay: 1
   changed_when: false
+  when: __metrics_is_booted | bool

--- a/tests/check_sasl.yml
+++ b/tests/check_sasl.yml
@@ -14,4 +14,5 @@
 - name: Check if a client can access metrics
   command: pminfo -f -h "pcp://127.0.0.1?username={{ __test_uname }}&password={{ pcptest_pw }}" disk.dev.read
   changed_when: false
+  when: __metrics_is_booted | bool
 # yamllint enable rule:line-length

--- a/tests/restore_services_state.yml
+++ b/tests/restore_services_state.yml
@@ -14,6 +14,7 @@
     state: "{{ 'started' if initial_state.ansible_facts.services[item + '.service']['state'] == 'running'
                else 'stopped' }}"
   when:
+    - __metrics_is_booted | bool
     - item + '.service' in final_state.ansible_facts.services
     - item + '.service' in initial_state.ansible_facts.services
     - initial_state.ansible_facts.services[item + '.service']['status'] != 'not-found'
@@ -31,4 +32,6 @@
   service:
     name: firewalld
     state: stopped
-  when: metrics_manage_firewall | bool
+  when:
+    - __metrics_is_booted | bool
+    - metrics_manage_firewall | bool

--- a/tests/tests_bz1855544.yml
+++ b/tests/tests_bz1855544.yml
@@ -36,6 +36,7 @@
           retries: 10
           delay: 1
           changed_when: false
+          when: __metrics_is_booted | bool
 
         - name: Flush handlers
           meta: flush_handlers

--- a/tests/tests_verify_auth.yml
+++ b/tests/tests_verify_auth.yml
@@ -32,6 +32,7 @@
           # noqa command-instead-of-module
           shell: systemctl restart pmcd && sleep 5
           changed_when: false
+          when: __metrics_is_booted | bool
 
         - name: Check if SASL works
           include_tasks: "{{ item }}"

--- a/tests/tests_verify_fullstack.yml
+++ b/tests/tests_verify_fullstack.yml
@@ -25,6 +25,20 @@
           include_role:
             name: linux-system-roles.metrics
             public: true
+          when: not __bootc_validation | d(false)
+
+        - name: Create QEMU deployment during bootc end-to-end test
+          delegate_to: localhost
+          command: "{{ lsr_scriptdir }}/bootc-buildah-qcow.sh {{ ansible_host }}"
+          changed_when: true
+          when: ansible_connection == "buildah"
+
+        # role does not run during bootc QEMU validation, thus some vars are undefined
+        - name: Set missing variables for bootc validation tests
+          set_fact:
+            __metrics_is_booted: true
+            metrics_provider: pcp
+          when: __bootc_validation | d(false)
 
         - name: Check if all services work
           include_tasks: "{{ item }}"
@@ -48,3 +62,4 @@
       always:
         - name: Restore state of services
           import_tasks: restore_services_state.yml
+          when: not __bootc_validation | d(false)

--- a/tests/tests_verify_postfix.yml
+++ b/tests/tests_verify_postfix.yml
@@ -58,6 +58,7 @@
         - name: Signal pmcd to ensure above path used by pmdapostfix
           command: pmstore pmcd.control.sighup 1
           changed_when: false
+          when: __metrics_is_booted | bool
 
         - name: Check Postfix functionality
           include_tasks: "{{ item }}"


### PR DESCRIPTION
Feature: Support running the cockpit role during container builds.

Reason: This is particularly useful for building bootc derivative OSes.

Result: The role now works during container builds. The bootc container scenarios run in CI, which ensures that the role works in buildah build environment. This allows us to officially support this role for image mode builds.

Detect if the system is booted (with systemd), and skip all runtime operations and checks if not. Also use `firewall-offline-cmd` which works also in non-booted environments -- we are only/primarily interested in the persistent firewall config anyway.

Make tests_verify_fullstack.yml a full bootc end-to-end test, as that covers the most code paths.

https://issues.redhat.com/browse/RHEL-98911

----

Requirements:
 - [x] https://github.com/performancecopilot/ansible-pcp/pull/82
 - [x] https://github.com/performancecopilot/ansible-pcp/pull/83
 - [x] https://github.com/performancecopilot/ansible-pcp/pull/84
 - [x] https://github.com/performancecopilot/ansible-pcp/pull/85
 - [x] update ansible-pcp in vendor/

## Summary by Sourcery

Enable the cockpit role to be executed during container (Buildah) image builds by detecting systemd boot status, skipping unsupported runtime operations, using persistent firewall tooling, and extending CI tests to cover buildah QEMU scenarios.

New Features:
- Detect systemd boot status and skip runtime operations in non-booted container build environments
- Switch firewall checks to use firewall-offline-cmd for persistent configuration

Enhancements:
- Guard tasks and tests on the new __metrics_is_booted flag to enable containerbuild support
- Convert tests_verify_fullstack.yml into a bootc end-to-end test with a Buildah QEMU deployment
- Update galaxy metadata tags to include containerbuild
- Introduce sudo_password vault variable for CI tests
- Conditionally adjust PCP command usage when systemd is not available

## Summary by Sourcery

Enable the metrics Ansible role to run in container (Buildah) image builds by detecting when systemd isn’t running, skipping unsupported runtime tasks, and anchoring firewall changes to persistent configuration.

New Features:
- Detect systemd boot status and skip runtime operations in non-booted container environments
- Switch firewall management to firewall-offline-cmd for persistent configuration

Enhancements:
- Guard tasks and tests on a __metrics_is_booted flag to enable containerbuild support
- Convert fullstack tests into a bootc end-to-end Buildah QEMU scenario
- Adjust PCP command usage when systemd is unavailable

Build:
- Add containerbuild tag to Galaxy metadata

CI:
- Extend CI workflows to run bootc container build scenarios and update tests to conditionally run on __metrics_is_booted