### PR TITLE
feat: add metrics_optional_domains and metrics_optional_packages for users to configure optional domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ It cannot be used for *removing* policy.
 If you want to remove policy, you will need to use the selinux system
 role directly.
 
+### metrics_optional_domains: []
+
+List of optional metrics domains to enable.  The role will enable the domains
+for components you are managing.  For example, if you use
+`metrics_from_elasticsearch: true`, the role will enable the elasticsearch
+domain automatically.  This variable is for additional domains.
+
+```yaml
+metrics_optional_domains: [apache]
+```
+
+### metrics_optional_packages: []
+
+Additional metrics packages that should be installed, beyond the default set, to
+enable additional metrics, export to alternate data sinks, and so on.
+
+```yaml
+metrics_optional_packages: [pcp-pmda-apache]
+```
+
 ## Example Playbook
 
 Basic metric recording setup for each managed host only, with one

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,3 +57,14 @@ metrics_manage_selinux: false
 # performance issues are to be sent.  By default, these events are logged to the
 # local system log only.
 metrics_webhook_endpoint: ''
+
+# List of optional PCP agents to enable.  The role will enable
+# agents for components you are managing.  For example, if you
+# use metrics_from_elasticsearch, the role will enable the
+# elasticsearch agent automatically.  This variable is for
+# additional agents.
+metrics_optional_domains: []
+
+# Additional metrics packages that should be installed, beyond the default set,
+# to enable additional metrics, export to alternate data sinks, and so on.
+metrics_optional_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,7 +127,8 @@
     pcp_pmie_endpoint: "{{ metrics_webhook_endpoint }}"
     pcp_pmlogger_discard: "{{ metrics_retention_days }}"
     pcp_target_hosts: "{{ metrics_monitored_hosts }}"
-    pcp_optional_agents: "{{ __metrics_domains }}"
+    pcp_optional_agents: "{{ (__metrics_domains + metrics_optional_domains) | unique | list }}"
+    pcp_optional_packages: "{{ metrics_optional_packages }}"
     pcp_accounts: "{{ __metrics_accounts }}"
     pcp_rest_api: "{{ metrics_query_service | bool or
                       metrics_graph_service | bool }}"

--- a/tests/tests_verify_fullstack.yml
+++ b/tests/tests_verify_fullstack.yml
@@ -7,6 +7,8 @@
     metrics_graph_service: true
     metrics_manage_firewall: true
     metrics_manage_selinux: true
+    metrics_optional_domains: [apache]
+    metrics_optional_packages: [pcp-pmda-apache]
 
   pre_tasks:
     - name: Stop test
@@ -51,6 +53,12 @@
             - check_grafana.yml
             - check_grafanapcp.yml
             - check_firewall_selinux.yml
+
+        - name: Check if optional apache domain is active
+          command: pminfo -f pmcd.agent.status
+          changed_when: false
+          register: __check
+          failed_when: __check is failed or __check is not search("apache")
 
         - name: Flush handlers
           meta: flush_handlers


### PR DESCRIPTION
Feature: The metrics role has access to many data collection domains.
The metrics role will automatically enable
domains for features being managed e.g. the metrics role will automatically
enable the `elasticsearch` domain if `metrics_from_elasticsearch: true`.  The
new parameter `metrics_optional_domains` allows the user to provide a list
of additional domains to enable.  The new parameter `metrics_optional_packages`
allows the user to provide a list of additional packages that may be required
to support the additional domains.

Reason: Users should be able to enable domains other than the ones for
features managed by the metrics role, and provide additional packages needed
to enable those domains.

Result: Users can enable the domains they need to use, and specify additional
packages required for those domains.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Introduce support for user-configurable optional PCP agents in the metrics role, allowing users to enable additional agents beyond those automatically managed by the role.

New Features:
- Add metrics_optional_domains variable to allow users to specify additional domains to enable.

Enhancements:
- Update task logic to enable both automatically managed and user-specified PCP agents.

Documentation:
- Document the new metrics_optional_domains variable and its usage in README.md.

Tests:
- Add test coverage for enabling optional PCP agents via metrics_optional_domains.