### PR TITLE
Update the subtree.yml workflow file to create a PR and merge

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -15,10 +15,40 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-      - name: subtree merge
+      - name: subtree merge and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          BRANCH_NAME="sync-ansible-pcp-subtree-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+
+          BEFORE_COMMIT=$(git rev-parse HEAD)
+          
           git subtree pull --prefix vendor/github.com/performancecopilot/ansible-pcp https://github.com/performancecopilot/ansible-pcp.git HEAD --squash
-          git push
+
+          if git diff --quiet "$BEFORE_COMMIT" HEAD; then
+            echo "No changes detected, skipping PR creation"
+            git checkout main
+            git branch -D "$BRANCH_NAME"
+            exit 0
+          fi
+          
+          git push origin "$BRANCH_NAME"
+
+          PR_URL=$(gh pr create \
+            --title "Sync ansible-pcp git subtree" \
+            --body "Automated sync of ansible-pcp git subtree from upstream repository. This PR contains the latest changes from https://github.com/performancecopilot/ansible-pcp.git" \
+            --base main \
+            --head "$BRANCH_NAME")
+          
+          echo "Created PR: $PR_URL"
+          
+          # Wait for PR to be fully created
+          sleep 10
+
+          gh pr merge "$PR_URL" --squash --delete-branch
+          echo "PR merged and branch deleted"


### PR DESCRIPTION
The "Sync ansible-pcp git subtree" github action no longer works as intended due to permission changes preventing directly pushing to main. This PR introduces changes to the subtree.yml workflow file to create and merge a PR, which is the accepted way of introducing changes.

## Summary by Sourcery

Switch the ansible-pcp subtree sync workflow from direct pushes to a PR-based process using the GitHub CLI to comply with updated permissions.

Enhancements:
- Replace direct subtree push with a PR-based merge process for ansible-pcp sync

CI:
- Generate a timestamped branch for each sync and skip PR creation when there are no changes
- Automate PR creation, squash merging, and branch cleanup via gh cli