### PR TITLE
add admin override option to ansible-pcp sync workflow

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -50,5 +50,5 @@ jobs:
           # Wait for PR to be fully created
           sleep 10
 
-          gh pr merge "$PR_URL" --squash --delete-branch
-          echo "PR merged and branch deleted"
+          gh pr merge "$PR_URL" --squash --delete-branch --admin
+          echo "PR merged with admin override and branch deleted"


### PR DESCRIPTION
As observed in #249, a PR needs at least 1 approval to allow merging. To work around this in the sync ansible-pcp git subtree action, the --admin option is now used when merging the PR. This allows bypassing the approval.

This may also require a change to the branch protection rules. It looks like the "Allow specified actors to bypass required pull requests" option needs to be enabled for the --admin option to work.

## Summary by Sourcery

Enable admin override when merging sync ansible-pcp subtree PRs

Enhancements:
- Add --admin flag to gh pr merge command in the subtree workflow
- Update merge confirmation message to reflect admin override and branch deletion