### PR TITLE
ci: Do not try to merge the PR in sync ansible-pcp subtree workflow

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -41,14 +41,12 @@ jobs:
 
           PR_URL=$(gh pr create \
             --title "Sync ansible-pcp git subtree" \
-            --body "Automated sync of ansible-pcp git subtree from upstream repository. This PR contains the latest changes from https://github.com/performancecopilot/ansible-pcp.git" \
+            --body "Automated sync of ansible-pcp git subtree from upstream repository. This PR contains the latest changes from https://github.com/performancecopilot/ansible-pcp.git
+            
+            You may see a conflict when trying to merge. This is expected as the PR contains a squash commit containing all the changes from the other commits.
+            
+            To successfully merge this PR, it should be merged via the squash and merge option. Click the dropdown next to the merge button to find the merge options. " \
             --base main \
             --head "$BRANCH_NAME")
           
           echo "Created PR: $PR_URL"
-          
-          # Wait for PR to be fully created
-          sleep 10
-
-          gh pr merge "$PR_URL" --squash --delete-branch --admin
-          echo "PR merged with admin override and branch deleted"


### PR DESCRIPTION
The github actions bot cannot approve and merge the PR it creates in the sync ansible-pcp git subtree workflow. The workflow will now just create the PR for a maintainer to review/approve and then merge.

In addition to changing how the workflow operates, there will also now be a more helpful comment at the top of the PR created by the action. The comment explains why there is a "conflict" when trying to merge via certain methods (i.e. rebase and merge). It then explains how to change to the "squash and merge" option, which is the correct way to merge the PR and will not have any conflicts.

## Summary by Sourcery

Update the GitHub Actions subtree sync workflow to no longer auto-merge PRs and to provide clearer merge instructions

CI:
- Remove automatic merging and branch deletion steps from the ansible-pcp subtree sync workflow
- Enhance the PR body with guidance on expected conflicts and instructions to use squash-and-merge