### PR TITLE
test: skip checking pmcd if not booted

### DIFF
--- a/tests/tests_verify_fullstack.yml
+++ b/tests/tests_verify_fullstack.yml
@@ -58,6 +58,7 @@
           command: pminfo -f pmcd.agent.status
           changed_when: false
           register: __check
+          when: __metrics_is_booted
           failed_when: __check is failed or __check is not search("apache")
 
         - name: Flush handlers


### PR DESCRIPTION
Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Skip pmcd status check in fullstack verification when the system is not booted