### PR TITLE
ci: fix the ansible-pcp subtree sync workflow

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -22,13 +22,16 @@ jobs:
           set -euxo pipefail
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
+
           BRANCH_NAME="sync-ansible-pcp-subtree-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH_NAME"
 
           BEFORE_COMMIT=$(git rev-parse HEAD)
-          
+
           git subtree pull --prefix vendor/github.com/performancecopilot/ansible-pcp https://github.com/performancecopilot/ansible-pcp.git HEAD --squash
+          # rebase the subtree changes onto main using the ort strategy with the subtree option
+          # didn't have to do this before, but now we do
+          git rebase main -s ort -X subtree=vendor/github.com/performancecopilot/ansible-pcp
 
           if git diff --quiet "$BEFORE_COMMIT" HEAD; then
             echo "No changes detected, skipping PR creation"
@@ -36,17 +39,9 @@ jobs:
             git branch -D "$BRANCH_NAME"
             exit 0
           fi
-          
+
           git push origin "$BRANCH_NAME"
 
-          PR_URL=$(gh pr create \
-            --title "Sync ansible-pcp git subtree" \
-            --body "Automated sync of ansible-pcp git subtree from upstream repository. This PR contains the latest changes from https://github.com/performancecopilot/ansible-pcp.git
-            
-            You may see a conflict when trying to merge. This is expected as the PR contains a squash commit containing all the changes from the other commits.
-            
-            To successfully merge this PR, it should be merged via the squash and merge option. Click the dropdown next to the merge button to find the merge options. " \
-            --base main \
-            --head "$BRANCH_NAME")
-          
-          echo "Created PR: $PR_URL"
+          gh pr create \
+            --title "refactor: sync latest changes from ansible-pcp" \
+            --body "Automated sync of ansible-pcp git subtree from upstream repository. This PR contains the latest changes from https://github.com/performancecopilot/ansible-pcp.git"


### PR DESCRIPTION
After some trial and error, I figured out that we need to rebase on top of main
using the merge strategy ort with the subtree option.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>