### PR TITLE
feat: new variable `metrics_secure_logging` defaulting to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,22 @@ the grafana server machine, where `basename` is the basename of `metrics_grafana
 metrics_grafana_private_key_src: /my/local/grafana-server.key
 ```
 
+### metrics_secure_logging: true
+
+If `true`, suppress potentially sensitive output from tasks that handle
+credentials, secrets, and other sensitive data by setting `no_log: true` on
+those tasks. This prevents passwords, API tokens, private keys, and similar
+sensitive information from appearing in Ansible logs and console output.
+
+If you need to debug issues with credential handling or secret management, you
+can temporarily set `metrics_secure_logging: false` to see the full output from
+these tasks. However, be aware that this may expose sensitive information in
+logs, so it should only be used in development or troubleshooting scenarios.
+
+```yaml
+metrics_secure_logging: true
+```
+
 ## Example Playbook
 
 Basic metric recording setup for each managed host only, with one

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,3 +75,4 @@ metrics_grafana_cert: ""
 metrics_grafana_private_key: ""
 metrics_grafana_cert_src: ""
 metrics_grafana_private_key_src: ""
+metrics_secure_logging: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,7 +170,7 @@
         owner: root
         group: root
       when: metrics_grafana_private_key_src | length > 0
-      no_log: true
+      no_log: "{{ metrics_secure_logging }}"
 
     - name: Setup metric graphing service.
       vars:


### PR DESCRIPTION
Feature: Introduce the `metrics_secure_logging` variable that defaults to `true`.

Reason: Currently, all sensitive tasks use hard-coded no_log: true, which makes debugging difficult. Users cannot see credential-related output even when troubleshooting authentication or secret management issues.

Result:
  - Tasks handling credentials, secrets, and sensitive data now use no_log: "{{ metrics_secure_logging }}", allowing users to set metrics_secure_logging: false for debugging while maintaining secure defaults (true)
  - New variable metrics_secure_logging documented in README.md with guidance on when to disable it
  - Users can now debug credential and secret issues without modifying role code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a configurable secure logging toggle for sensitive metrics tasks.

New Features:
- Add the metrics_secure_logging variable, defaulting to true, to control logging of sensitive metrics-related tasks.

Documentation:
- Document the metrics_secure_logging variable and guidance on when to disable secure logging for troubleshooting.